### PR TITLE
feat(server): Add support of Lago headers for auth

### DIFF
--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -56,7 +56,9 @@ impl LagoMcpServer {
         parameters: Parameters<crate::tools::invoice::ListInvoicesArgs>,
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
-        self.invoice_service.list_invoices(parameters, context).await
+        self.invoice_service
+            .list_invoices(parameters, context)
+            .await
     }
 
     #[tool(description = "Get a specific customer by their external ID")]
@@ -65,7 +67,9 @@ impl LagoMcpServer {
         parameters: Parameters<crate::tools::customer::GetCustomerArgs>,
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
-        self.customer_service.get_customer(parameters, context).await
+        self.customer_service
+            .get_customer(parameters, context)
+            .await
     }
 
     #[tool(
@@ -76,7 +80,9 @@ impl LagoMcpServer {
         parameters: Parameters<crate::tools::customer::ListCustomersArgs>,
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
-        self.customer_service.list_customers(parameters, context).await
+        self.customer_service
+            .list_customers(parameters, context)
+            .await
     }
 
     #[tool(description = "Create or update a customer in Lago")]

--- a/mcp/src/tools.rs
+++ b/mcp/src/tools.rs
@@ -3,15 +3,16 @@ pub mod customer;
 pub mod invoice;
 
 use lago_client::{Config, Credentials, LagoClient, Region};
-use serde::Serialize;
 use rmcp::{
-    service::RequestContext,
     RoleServer,
-    model::{CallToolResult, Content}
+    model::{CallToolResult, Content},
+    service::RequestContext,
 };
+use serde::Serialize;
 
-
-pub async fn create_lago_client(context: &RequestContext<RoleServer>,) -> Result<LagoClient, CallToolResult> {
+pub async fn create_lago_client(
+    context: &RequestContext<RoleServer>,
+) -> Result<LagoClient, CallToolResult> {
     let (header_key, header_url) = context
         .extensions
         .get::<axum::http::request::Parts>()
@@ -33,7 +34,10 @@ pub async fn create_lago_client(context: &RequestContext<RoleServer>,) -> Result
     if let (Some(key), Some(url)) = (header_key, header_url) {
         let credentials = Credentials::new(key);
         let region = Region::Custom(url);
-        let config = Config::builder().credentials(credentials).region(region).build();
+        let config = Config::builder()
+            .credentials(credentials)
+            .region(region)
+            .build();
         return Ok(LagoClient::new(config));
     }
 

--- a/mcp/src/tools/billable_metric.rs
+++ b/mcp/src/tools/billable_metric.rs
@@ -1,10 +1,5 @@
 use anyhow::Result;
-use rmcp::{
-    handler::server::tool::Parameters,
-    service::RequestContext,
-    RoleServer,
-    model::*
-};
+use rmcp::{RoleServer, handler::server::tool::Parameters, model::*, service::RequestContext};
 use serde::{Deserialize, Serialize};
 
 use lago_types::{

--- a/mcp/src/tools/customer.rs
+++ b/mcp/src/tools/customer.rs
@@ -1,10 +1,5 @@
 use anyhow::Result;
-use rmcp::{
-    handler::server::tool::Parameters,
-    service::RequestContext,
-    RoleServer,
-    model::*
-};
+use rmcp::{RoleServer, handler::server::tool::Parameters, model::*, service::RequestContext};
 use serde::{Deserialize, Serialize};
 
 use lago_types::{

--- a/mcp/src/tools/invoice.rs
+++ b/mcp/src/tools/invoice.rs
@@ -1,10 +1,5 @@
 use anyhow::Result;
-use rmcp::{
-    RoleServer,
-    handler::server::tool::Parameters,
-    service::RequestContext,
-    model::*
-};
+use rmcp::{RoleServer, handler::server::tool::Parameters, model::*, service::RequestContext};
 use serde::{Deserialize, Serialize};
 
 use lago_types::{
@@ -12,7 +7,6 @@ use lago_types::{
     models::{InvoicePaymentStatus, InvoiceStatus, InvoiceType, PaginationParams},
     requests::invoice::{GetInvoiceRequest, ListInvoicesRequest},
 };
-
 
 use crate::tools::{create_lago_client, error_result, success_result};
 


### PR DESCRIPTION
- Add support of `X-LAGO-API-KEY` and `X-LAGO-API-URL` in mcp server headers for auth, instead of using env vars
- If those headers are not present, it will fallback to env vars