### PR TITLE
Setup cargo-watch for live reload

### DIFF
--- a/mcp/Dockerfile.dev
+++ b/mcp/Dockerfile.dev
@@ -1,0 +1,22 @@
+FROM rust:1.88-slim-trixie
+
+RUN apt-get update && apt-get install -y \
+    pkg-config \
+    libssl-dev \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN cargo install cargo-watch
+
+WORKDIR /app
+
+RUN cargo init . --name lago-mcp-server
+
+COPY Cargo.toml Cargo.lock ./
+
+RUN cargo fetch
+
+ENV PATH="/usr/local/cargo/bin:${PATH}"
+ENV RUST_LOG=info
+
+CMD ["cargo", "watch", "-x", "run -- sse --host 0.0.0.0 --port 3001"]

--- a/mcp/docker-compose.dev.yml
+++ b/mcp/docker-compose.dev.yml
@@ -4,16 +4,18 @@ services:
     container_name: lago_mcp_server_dev
     build:
       context: $LAGO_MCP_SERVER_PATH
-      dockerfile: $LAGO_MCP_SERVER_PATH/Dockerfile
+      dockerfile: $LAGO_MCP_SERVER_PATH/Dockerfile.dev
     restart: unless-stopped
-    command: ["./lago-mcp-server", "sse", "--host", "0.0.0.0", "--port", "3001"]
     env_file:
       - path: ./.env.development
         required: false
     environment:
       - LAGO_API_URL=https://api.lago.dev/api/v1
+      - RUST_LOG=info
     ports:
       - "3001:3001"
+    volumes:
+      - $LAGO_MCP_SERVER_PATH:/app:delegated
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.mcp_server.rule=Host(`mcp.lago.dev`)"


### PR DESCRIPTION
The goal of this PR is to setup cargo-watch for tracking changes locally automatically.
We haven't setup [bacon](https://github.com/Canop/bacon) as it does not work correctly with Docker.