### PR TITLE
feat: Add subscription, plan and usage tool

### DIFF
--- a/mcp/Cargo.lock
+++ b/mcp/Cargo.lock
@@ -915,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "lago-client"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "985bdd26deb36138717926746406b3746e8242e514eea38fd7012fd04960548a"
+checksum = "4b04962cc954441c084e777394d12b29950da806152432bdf8a8cca40320935e"
 dependencies = [
  "anyhow",
  "lago-types",
@@ -955,9 +955,9 @@ dependencies = [
 
 [[package]]
 name = "lago-types"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f699d7c18f5d7f36895d6eeb1f9c987a6bb5372af6b214ebfa461d7189b78d9e"
+checksum = "af4c2f2e3b80a07fa078dd8673ae9fac2499b4771afbb9ba97f2576483673963"
 dependencies = [
  "chrono",
  "reqwest",

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -23,8 +23,8 @@ async-trait = "0.1"
 schemars = { version = "1.0", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-lago-client = "0.1.12"
-lago-types = "0.1.12"
+lago-client = "0.1.13"
+lago-types = "0.1.13"
 clap = { version = "4.5", features = ["derive"] }
 tokio-util = "0.7"
 axum = { version = "0.8", features = ["macros"] }

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -12,12 +12,15 @@ The Model Context Protocol (MCP) is a standardized way for AI assistants to inte
 
 - **Invoice Management**: Query and retrieve invoice data from Lago
 - **Customer Management**: Create, retrieve, and list customers in Lago
+- **Customer Usage**: Retrieve current usage data for a customer's subscription
+- **Subscription Management**: Create, update, list, and delete subscriptions in Lago
+- **Plan Management**: Create, update, list, and delete plans in Lago
 - **Billable Metric Management**: Create, retrieve, and list billable metrics in Lago
 - **Activity Log Management**: Query activity logs to track actions performed on resources
 - **API Log Management**: Query API logs to monitor API requests and responses
 - **Applied Coupon Management**: Apply coupons to customers and list applied coupons
 - **Event Management**: Send and retrieve usage events for billing
-- **Filtering Support**: Filter invoices, customers, billable metrics, logs, and applied coupons by various criteria
+- **Filtering Support**: Filter invoices, customers, subscriptions, plans, billable metrics, logs, and applied coupons by various criteria
 - **Pagination**: Handle large result sets with built-in pagination
 - **Type Safety**: Fully typed requests and responses using Rust
 - **Multi-tenant Support**: Per-request client creation for handling multiple tenants
@@ -145,9 +148,36 @@ Create or update a customer in Lago.
 }
 ```
 
+### Customer Usage Tools
+
+#### 6. `get_customer_current_usage`
+Get the current usage for a customer's subscription. This endpoint retrieves the usage-based billing data for a customer within the current billing period.
+
+**Parameters:**
+- `external_customer_id` (string, required): The external unique identifier of the customer (provided by your own application)
+- `external_subscription_id` (string, required): The unique identifier of the subscription within your application
+- `apply_taxes` (boolean, optional): Optional flag to determine if taxes should be applied. Defaults to true if not provided.
+
+**Example:**
+```json
+{
+  "external_customer_id": "customer_123",
+  "external_subscription_id": "subscription_456"
+}
+```
+
+**Example with taxes disabled:**
+```json
+{
+  "external_customer_id": "customer_123",
+  "external_subscription_id": "subscription_456",
+  "apply_taxes": false
+}
+```
+
 ### Billable Metric Tools
 
-#### 6. `get_billable_metric`
+#### 7. `get_billable_metric`
 Retrieve a specific billable metric by its code.
 
 **Parameters:**
@@ -160,7 +190,7 @@ Retrieve a specific billable metric by its code.
 }
 ```
 
-#### 7. `list_billable_metrics`
+#### 8. `list_billable_metrics`
 List billable metrics with optional filtering and pagination.
 
 **Parameters:**
@@ -180,7 +210,7 @@ List billable metrics with optional filtering and pagination.
 }
 ```
 
-#### 8. `create_billable_metric`
+#### 9. `create_billable_metric`
 Create a new billable metric in Lago.
 
 **Parameters:**
@@ -224,7 +254,7 @@ Create a new billable metric in Lago.
 
 ### Activity Log Tools
 
-#### 9. `get_activity_log`
+#### 10. `get_activity_log`
 Retrieve a specific activity log by its activity ID.
 
 **Parameters:**
@@ -237,7 +267,7 @@ Retrieve a specific activity log by its activity ID.
 }
 ```
 
-#### 10. `list_activity_logs`
+#### 11. `list_activity_logs`
 List activity logs with optional filtering and pagination.
 
 **Parameters:**
@@ -269,7 +299,7 @@ List activity logs with optional filtering and pagination.
 
 ### API Log Tools
 
-#### 11. `get_api_log`
+#### 12. `get_api_log`
 Retrieve a specific API log by its request ID.
 
 **Parameters:**
@@ -282,7 +312,7 @@ Retrieve a specific API log by its request ID.
 }
 ```
 
-#### 12. `list_api_logs`
+#### 13. `list_api_logs`
 List API logs with optional filtering and pagination.
 
 **Parameters:**
@@ -312,7 +342,7 @@ List API logs with optional filtering and pagination.
 
 ### Event Tools
 
-#### 13. `get_event`
+#### 14. `get_event`
 Retrieve a specific usage event by its transaction ID.
 
 **Parameters:**
@@ -325,7 +355,7 @@ Retrieve a specific usage event by its transaction ID.
 }
 ```
 
-#### 14. `create_event`
+#### 15. `create_event`
 Send a usage event to Lago. Events are used to track customer usage and are aggregated into invoice line items based on billable metrics.
 
 **Parameters:**
@@ -360,7 +390,7 @@ Send a usage event to Lago. Events are used to track customer usage and are aggr
 
 ### Applied Coupon Tools
 
-#### 16. `list_applied_coupons`
+#### 17. `list_applied_coupons`
 List applied coupons with optional filtering and pagination.
 
 **Parameters:**
@@ -382,7 +412,7 @@ List applied coupons with optional filtering and pagination.
 }
 ```
 
-#### 17. `apply_coupon`
+#### 18. `apply_coupon`
 Apply a coupon to a customer. Use this to give discounts before or during a subscription.
 
 **Parameters:**
@@ -402,6 +432,265 @@ Apply a coupon to a customer. Use this to give discounts before or during a subs
   "coupon_code": "WELCOME10",
   "frequency": "recurring",
   "frequency_duration": 6
+}
+```
+
+### Subscription Tools
+
+#### 19. `list_subscriptions`
+List subscriptions with optional filtering and pagination.
+
+**Parameters:**
+- `plan_code` (string, optional): Filter by plan code
+- `status` (array of strings, optional): Filter by subscription status
+  - Possible values: `active`, `pending`, `canceled`, `terminated`
+- `page` (integer, optional): Page number for pagination (default: 1)
+- `per_page` (integer, optional): Number of items per page (default: 20)
+
+**Example:**
+```json
+{
+  "plan_code": "starter_plan",
+  "status": ["active", "pending"],
+  "page": 1,
+  "per_page": 10
+}
+```
+
+#### 20. `get_subscription`
+Retrieve a specific subscription by its external ID.
+
+**Parameters:**
+- `external_id` (string, required): The external unique identifier of the subscription
+
+**Example:**
+```json
+{
+  "external_id": "sub_123"
+}
+```
+
+#### 21. `list_customer_subscriptions`
+List subscriptions for a specific customer with optional filtering and pagination.
+
+**Parameters:**
+- `external_customer_id` (string, required): The external unique identifier of the customer
+- `plan_code` (string, optional): Filter by plan code
+- `status` (array of strings, optional): Filter by subscription status
+  - Possible values: `active`, `pending`, `canceled`, `terminated`
+- `page` (integer, optional): Page number for pagination (default: 1)
+- `per_page` (integer, optional): Number of items per page (default: 20)
+
+**Example:**
+```json
+{
+  "external_customer_id": "customer_123",
+  "status": ["active"],
+  "page": 1,
+  "per_page": 10
+}
+```
+
+#### 22. `create_subscription`
+Create a new subscription for a customer.
+
+**Parameters:**
+- `external_customer_id` (string, required): External unique identifier for the customer
+- `plan_code` (string, required): Code of the plan to assign to the subscription
+- `name` (string, optional): Optional display name for the subscription
+- `external_id` (string, optional): Optional external unique identifier for the subscription
+- `billing_time` (string, optional): Billing time determines when recurring billing cycles occur
+  - Possible values: `anniversary`, `calendar`
+- `subscription_at` (string, optional): The subscription start date (ISO 8601 format)
+- `ending_at` (string, optional): The subscription end date (ISO 8601 format)
+- `plan_overrides` (object, optional): Plan overrides to customize the plan for this subscription
+  - `amount_cents` (integer, optional): Override the base amount in cents
+  - `amount_currency` (string, optional): Override the currency
+  - `description` (string, optional): Override the plan description
+  - `invoice_display_name` (string, optional): Override the invoice display name
+  - `name` (string, optional): Override the plan name
+  - `trial_period` (number, optional): Override the trial period in days
+
+**Example:**
+```json
+{
+  "external_customer_id": "customer_123",
+  "plan_code": "starter_plan",
+  "name": "My Subscription",
+  "external_id": "sub_001",
+  "billing_time": "calendar",
+  "subscription_at": "2025-01-01T00:00:00Z",
+  "plan_overrides": {
+    "amount_cents": 9900,
+    "trial_period": 14
+  }
+}
+```
+
+#### 23. `update_subscription`
+Update an existing subscription.
+
+**Parameters:**
+- `external_id` (string, required): The external unique identifier of the subscription to update
+- `name` (string, optional): Optional new name for the subscription
+- `ending_at` (string, optional): Optional new end date for the subscription (ISO 8601 format)
+- `plan_code` (string, optional): Optional new plan code (for plan changes)
+- `subscription_at` (string, optional): Optional new subscription date (ISO 8601 format)
+- `plan_overrides` (object, optional): Plan overrides to customize the plan for this subscription
+
+**Example:**
+```json
+{
+  "external_id": "sub_001",
+  "name": "Updated Subscription Name",
+  "ending_at": "2025-12-31T23:59:59Z"
+}
+```
+
+#### 24. `delete_subscription`
+Terminate a subscription.
+
+**Parameters:**
+- `external_id` (string, required): The external unique identifier of the subscription to terminate
+- `status` (string, optional): Optional status to set the subscription to (defaults to terminated)
+
+**Example:**
+```json
+{
+  "external_id": "sub_001"
+}
+```
+
+### Plan Tools
+
+#### 25. `list_plans`
+List all plans with optional pagination.
+
+**Parameters:**
+- `page` (integer, optional): Page number for pagination (default: 1)
+- `per_page` (integer, optional): Number of items per page (default: 20)
+
+**Example:**
+```json
+{
+  "page": 1,
+  "per_page": 10
+}
+```
+
+#### 26. `get_plan`
+Retrieve a specific plan by its unique code.
+
+**Parameters:**
+- `code` (string, required): The unique code of the plan
+
+**Example:**
+```json
+{
+  "code": "starter_plan"
+}
+```
+
+#### 27. `create_plan`
+Create a new plan in Lago. Plans define pricing configuration with billing interval, base amount, and optional usage-based charges.
+
+**Parameters:**
+- `name` (string, required): Name of the plan
+- `code` (string, required): Unique code for the plan
+- `interval` (string, required): Billing interval
+  - Possible values: `weekly`, `monthly`, `quarterly`, `semiannual`, `yearly`
+- `amount_cents` (integer, required): Base amount in cents
+- `amount_currency` (string, required): Currency for the amount (e.g., USD, EUR)
+- `invoice_display_name` (string, optional): Display name for invoices
+- `description` (string, optional): Description of the plan
+- `trial_period` (number, optional): Trial period in days
+- `pay_in_advance` (boolean, optional): Whether the plan is billed in advance
+- `bill_charges_monthly` (boolean, optional): Whether charges are billed monthly for yearly plans
+- `tax_codes` (array, optional): Tax codes for this plan
+- `charges` (array, optional): Usage-based charges for this plan
+  - Each charge has: `billable_metric_id`, `charge_model` (standard, graduated, volume, package, percentage), `properties`, etc.
+- `minimum_commitment` (object, optional): Minimum commitment configuration
+  - `amount_cents` (integer): Minimum commitment amount
+  - `invoice_display_name` (string, optional): Display name
+  - `tax_codes` (array, optional): Tax codes
+- `usage_thresholds` (array, optional): Usage thresholds for progressive billing
+  - Each threshold has: `amount_cents`, `threshold_display_name`, `recurring`
+
+**Example:**
+```json
+{
+  "name": "Starter Plan",
+  "code": "starter_plan",
+  "interval": "monthly",
+  "amount_cents": 9900,
+  "amount_currency": "USD",
+  "description": "Our starter plan for small teams",
+  "pay_in_advance": true,
+  "trial_period": 14
+}
+```
+
+**Example with charges:**
+```json
+{
+  "name": "Usage Plan",
+  "code": "usage_plan",
+  "interval": "monthly",
+  "amount_cents": 4900,
+  "amount_currency": "USD",
+  "charges": [
+    {
+      "billable_metric_id": "metric_lago_id",
+      "charge_model": "standard",
+      "invoiceable": true,
+      "properties": {"amount": "0.01"}
+    }
+  ]
+}
+```
+
+#### 28. `update_plan`
+Update an existing plan in Lago.
+
+**Parameters:**
+- `code` (string, required): The code of the plan to update
+- `name` (string, optional): New name of the plan
+- `new_code` (string, optional): New code for the plan
+- `interval` (string, optional): Billing interval
+- `amount_cents` (integer, optional): Base amount in cents
+- `amount_currency` (string, optional): Currency for the amount
+- `invoice_display_name` (string, optional): Display name for invoices
+- `description` (string, optional): Description of the plan
+- `trial_period` (number, optional): Trial period in days
+- `pay_in_advance` (boolean, optional): Whether the plan is billed in advance
+- `bill_charges_monthly` (boolean, optional): Whether charges are billed monthly
+- `tax_codes` (array, optional): Tax codes for this plan
+- `charges` (array, optional): Charges for this plan
+- `minimum_commitment` (object, optional): Minimum commitment configuration
+- `usage_thresholds` (array, optional): Usage thresholds
+- `cascade_updates` (boolean, optional): Whether to cascade updates to existing subscriptions
+
+**Example:**
+```json
+{
+  "code": "starter_plan",
+  "name": "Updated Starter Plan",
+  "amount_cents": 12900,
+  "description": "Updated description",
+  "cascade_updates": true
+}
+```
+
+#### 29. `delete_plan`
+Delete a plan by its unique code. Note: This plan could be associated with active subscriptions.
+
+**Parameters:**
+- `code` (string, required): The code of the plan to delete
+
+**Example:**
+```json
+{
+  "code": "starter_plan"
 }
 ```
 
@@ -562,12 +851,49 @@ All tools return JSON responses with the following structure:
 }
 ```
 
+### Customer Usage Data
+```json
+{
+  "customer_usage": {
+    "from_datetime": "2024-01-01T00:00:00Z",
+    "to_datetime": "2024-01-31T23:59:59Z",
+    "issuing_date": "2024-02-01",
+    "lago_invoice_id": null,
+    "currency": "USD",
+    "amount_cents": 15000,
+    "taxes_amount_cents": 1500,
+    "total_amount_cents": 16500,
+    "charges_usage": [
+      {
+        "units": "150.0",
+        "events_count": 45,
+        "amount_cents": 15000,
+        "amount_currency": "USD",
+        "charge": {
+          "lago_id": "uuid",
+          "charge_model": "standard",
+          "invoice_display_name": "API Calls"
+        },
+        "billable_metric": {
+          "lago_id": "uuid",
+          "name": "API Calls",
+          "code": "api_calls",
+          "aggregation_type": "count_agg"
+        },
+        "filters": [],
+        "grouped_usage": []
+      }
+    ]
+  }
+}
+```
+
 ### Billable Metric Data
 ```json
 {
   "lago_id": "uuid",
   "name": "Storage Usage",
-  "code": "storage_gb", 
+  "code": "storage_gb",
   "description": "Tracks storage usage in gigabytes",
   "aggregation_type": "sum_agg",
   "recurring": false,
@@ -773,6 +1099,111 @@ All tools return JSON responses with the following structure:
 }
 ```
 
+### Subscription Data
+```json
+{
+  "subscription": {
+    "lago_id": "uuid",
+    "external_id": "sub_001",
+    "lago_customer_id": "uuid",
+    "external_customer_id": "customer_123",
+    "billing_time": "calendar",
+    "name": "My Subscription",
+    "plan_code": "starter_plan",
+    "status": "active",
+    "created_at": "2024-01-15T10:30:00Z",
+    "canceled_at": null,
+    "started_at": "2024-01-15T10:30:00Z",
+    "ending_at": null,
+    "subscription_at": "2024-01-15T10:30:00Z",
+    "terminated_at": null,
+    "previous_plan_code": null,
+    "next_plan_code": null,
+    "downgrade_plan_date": null,
+    "trial_ended_at": null,
+    "current_billing_period_started_at": "2024-01-01T00:00:00Z",
+    "current_billing_period_ending_at": "2024-01-31T23:59:59Z",
+    "plan": {
+      "lago_id": "uuid",
+      "name": "Starter Plan",
+      "invoice_display_name": null,
+      "created_at": "2024-01-01T00:00:00Z",
+      "code": "starter_plan",
+      "interval": "monthly",
+      "description": null,
+      "amount_cents": 9900,
+      "amount_currency": "USD",
+      "trial_period": 0.0,
+      "pay_in_advance": true,
+      "bill_charges_monthly": null,
+      "active_subscriptions_count": 10,
+      "draft_invoices_count": 0,
+      "parent_id": null,
+      "taxes": []
+    }
+  }
+}
+```
+
+**For subscription lists:**
+```json
+{
+  "subscriptions": [
+    // Array of subscription objects
+  ],
+  "pagination": {
+    "current_page": 1,
+    "total_pages": 5,
+    "total_count": 100,
+    "next_page": 2,
+    "prev_page": null
+  }
+}
+```
+
+### Plan Data
+```json
+{
+  "plan": {
+    "lago_id": "uuid",
+    "name": "Starter Plan",
+    "invoice_display_name": null,
+    "created_at": "2024-01-01T00:00:00Z",
+    "code": "starter_plan",
+    "interval": "monthly",
+    "description": "Our starter plan for small teams",
+    "amount_cents": 9900,
+    "amount_currency": "USD",
+    "trial_period": 14.0,
+    "pay_in_advance": true,
+    "bill_charges_monthly": null,
+    "active_subscriptions_count": 10,
+    "draft_invoices_count": 0,
+    "parent_id": null,
+    "charges": [],
+    "taxes": [],
+    "minimum_commitment": null,
+    "usage_thresholds": []
+  }
+}
+```
+
+**For plan lists:**
+```json
+{
+  "plans": [
+    // Array of plan objects
+  ],
+  "pagination": {
+    "current_page": 1,
+    "total_pages": 3,
+    "total_count": 25,
+    "next_page": 2,
+    "prev_page": null
+  }
+}
+```
+
 ## Development
 
 ### Project Structure
@@ -788,8 +1219,11 @@ mcp/
 │   │   ├── billable_metric.rs # Billable metric-related tools
 │   │   ├── coupon.rs          # Coupon-related tools
 │   │   ├── customer.rs        # Customer-related tools
+│   │   ├── customer_usage.rs  # Customer usage-related tools
 │   │   ├── event.rs           # Event-related tools
-│   │   └── invoice.rs         # Invoice-related tools
+│   │   ├── invoice.rs         # Invoice-related tools
+│   │   ├── plan.rs            # Plan-related tools
+│   │   └── subscription.rs    # Subscription-related tools
 │   └── tools.rs         # Shared utilities and client creation
 ├── Cargo.toml           # Rust dependencies
 └── Dockerfile           # Docker configuration

--- a/mcp/src/tools.rs
+++ b/mcp/src/tools.rs
@@ -5,8 +5,11 @@ pub mod billable_metric;
 pub mod coupon;
 pub mod credit_note;
 pub mod customer;
+pub mod customer_usage;
 pub mod event;
 pub mod invoice;
+pub mod plan;
+pub mod subscription;
 
 use lago_client::{Config, Credentials, LagoClient, Region};
 use rmcp::{

--- a/mcp/src/tools/customer_usage.rs
+++ b/mcp/src/tools/customer_usage.rs
@@ -1,0 +1,61 @@
+use anyhow::Result;
+use rmcp::{RoleServer, handler::server::tool::Parameters, model::*, service::RequestContext};
+use serde::{Deserialize, Serialize};
+
+use lago_types::requests::customer_usage::GetCustomerCurrentUsageRequest;
+
+use crate::tools::{create_lago_client, error_result, success_result};
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct GetCustomerCurrentUsageArgs {
+    /// The external unique identifier of the customer (provided by your own application).
+    pub external_customer_id: String,
+    /// The unique identifier of the subscription within your application.
+    pub external_subscription_id: String,
+    /// Optional flag to determine if taxes should be applied. Defaults to true if not provided.
+    pub apply_taxes: Option<bool>,
+}
+
+#[derive(Clone)]
+pub struct CustomerUsageService;
+
+impl CustomerUsageService {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub async fn get_customer_current_usage(
+        &self,
+        Parameters(args): Parameters<GetCustomerCurrentUsageArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let client = match create_lago_client(&context).await {
+            Ok(client) => client,
+            Err(error_result) => return Ok(error_result),
+        };
+
+        let mut request = GetCustomerCurrentUsageRequest::new(
+            args.external_customer_id,
+            args.external_subscription_id,
+        );
+
+        if let Some(apply_taxes) = args.apply_taxes {
+            request = request.with_apply_taxes(apply_taxes);
+        }
+
+        match client.get_customer_current_usage(request).await {
+            Ok(response) => {
+                let result = serde_json::json!({
+                    "customer_usage": response.customer_usage,
+                });
+
+                Ok(success_result(&result))
+            }
+            Err(e) => {
+                let error_message = format!("Failed to get customer current usage: {e}");
+                tracing::error!("{error_message}");
+                Ok(error_result(error_message))
+            }
+        }
+    }
+}

--- a/mcp/src/tools/plan.rs
+++ b/mcp/src/tools/plan.rs
@@ -1,0 +1,519 @@
+use anyhow::Result;
+use rmcp::{RoleServer, handler::server::tool::Parameters, model::*, service::RequestContext};
+use serde::{Deserialize, Serialize};
+
+use lago_types::{
+    models::{ChargeModel, PaginationParams, PlanInterval},
+    requests::plan::{
+        CreateChargeFilterInput, CreateMinimumCommitmentInput, CreatePlanChargeInput,
+        CreatePlanInput, CreatePlanRequest, CreateUsageThresholdInput, DeletePlanRequest,
+        GetPlanRequest, ListPlansRequest, UpdatePlanInput, UpdatePlanRequest,
+    },
+};
+
+use crate::tools::{create_lago_client, error_result, success_result};
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct ListPlansArgs {
+    /// Page number for pagination (default: 1).
+    pub page: Option<i32>,
+    /// Number of items per page (default: 20).
+    pub per_page: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct GetPlanArgs {
+    /// The unique code of the plan.
+    pub code: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct CreatePlanArgs {
+    /// Name of the plan.
+    pub name: String,
+    /// Unique code for the plan.
+    pub code: String,
+    /// Billing interval. Possible values: weekly, monthly, quarterly, semiannual, yearly.
+    pub interval: String,
+    /// Base amount in cents.
+    pub amount_cents: i64,
+    /// Currency for the amount (e.g., USD, EUR).
+    pub amount_currency: String,
+    /// Display name for invoices.
+    pub invoice_display_name: Option<String>,
+    /// Description of the plan.
+    pub description: Option<String>,
+    /// Trial period in days.
+    pub trial_period: Option<f64>,
+    /// Whether the plan is billed in advance.
+    pub pay_in_advance: Option<bool>,
+    /// Whether charges are billed monthly for yearly plans.
+    pub bill_charges_monthly: Option<bool>,
+    /// Tax codes for this plan.
+    pub tax_codes: Option<Vec<String>>,
+    /// Charges for this plan.
+    pub charges: Option<Vec<CreatePlanChargeArgs>>,
+    /// Minimum commitment for this plan.
+    pub minimum_commitment: Option<MinimumCommitmentArgs>,
+    /// Usage thresholds for progressive billing.
+    pub usage_thresholds: Option<Vec<UsageThresholdArgs>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct CreatePlanChargeArgs {
+    /// The billable metric ID to reference.
+    pub billable_metric_id: String,
+    /// The charge model to use. Possible values: standard, graduated, volume, package, percentage, graduated_percentage, dynamic.
+    pub charge_model: String,
+    /// Whether the charge is invoiceable.
+    pub invoiceable: Option<bool>,
+    /// Display name for the charge on invoices.
+    pub invoice_display_name: Option<String>,
+    /// Whether the charge is billed in advance.
+    pub pay_in_advance: Option<bool>,
+    /// Whether the charge is prorated.
+    pub prorated: Option<bool>,
+    /// Minimum amount in cents for this charge.
+    pub min_amount_cents: Option<i64>,
+    /// Charge properties (model-specific configuration as JSON).
+    pub properties: Option<serde_json::Value>,
+    /// Tax codes for this charge.
+    pub tax_codes: Option<Vec<String>>,
+    /// Filters for differentiated pricing.
+    pub filters: Option<Vec<ChargeFilterArgs>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct ChargeFilterArgs {
+    /// Invoice display name for this filter.
+    pub invoice_display_name: Option<String>,
+    /// Filter properties.
+    pub properties: Option<serde_json::Value>,
+    /// Filter values mapping.
+    pub values: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct MinimumCommitmentArgs {
+    /// Minimum commitment amount in cents.
+    pub amount_cents: i64,
+    /// Invoice display name for the minimum commitment.
+    pub invoice_display_name: Option<String>,
+    /// Tax codes for the minimum commitment.
+    pub tax_codes: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct UsageThresholdArgs {
+    /// Threshold amount in cents.
+    pub amount_cents: i64,
+    /// Display name for the threshold.
+    pub threshold_display_name: Option<String>,
+    /// Whether the threshold is recurring.
+    pub recurring: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct UpdatePlanArgs {
+    /// The code of the plan to update.
+    pub code: String,
+    /// New name of the plan.
+    pub name: Option<String>,
+    /// New code for the plan.
+    pub new_code: Option<String>,
+    /// Billing interval. Possible values: weekly, monthly, quarterly, semiannual, yearly.
+    pub interval: Option<String>,
+    /// Base amount in cents.
+    pub amount_cents: Option<i64>,
+    /// Currency for the amount.
+    pub amount_currency: Option<String>,
+    /// Display name for invoices.
+    pub invoice_display_name: Option<String>,
+    /// Description of the plan.
+    pub description: Option<String>,
+    /// Trial period in days.
+    pub trial_period: Option<f64>,
+    /// Whether the plan is billed in advance.
+    pub pay_in_advance: Option<bool>,
+    /// Whether charges are billed monthly for yearly plans.
+    pub bill_charges_monthly: Option<bool>,
+    /// Tax codes for this plan.
+    pub tax_codes: Option<Vec<String>>,
+    /// Charges for this plan.
+    pub charges: Option<Vec<CreatePlanChargeArgs>>,
+    /// Minimum commitment for this plan.
+    pub minimum_commitment: Option<MinimumCommitmentArgs>,
+    /// Usage thresholds for progressive billing.
+    pub usage_thresholds: Option<Vec<UsageThresholdArgs>>,
+    /// Whether to cascade updates to existing subscriptions.
+    pub cascade_updates: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct DeletePlanArgs {
+    /// The code of the plan to delete.
+    pub code: String,
+}
+
+#[derive(Clone)]
+pub struct PlanService;
+
+impl PlanService {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn parse_interval(interval_str: &str) -> Option<PlanInterval> {
+        match interval_str.to_lowercase().as_str() {
+            "weekly" => Some(PlanInterval::Weekly),
+            "monthly" => Some(PlanInterval::Monthly),
+            "quarterly" => Some(PlanInterval::Quarterly),
+            "semiannual" => Some(PlanInterval::Semiannual),
+            "yearly" => Some(PlanInterval::Yearly),
+            _ => None,
+        }
+    }
+
+    fn parse_charge_model(model_str: &str) -> Option<ChargeModel> {
+        match model_str.to_lowercase().as_str() {
+            "standard" => Some(ChargeModel::Standard),
+            "graduated" => Some(ChargeModel::Graduated),
+            "volume" => Some(ChargeModel::Volume),
+            "package" => Some(ChargeModel::Package),
+            "percentage" => Some(ChargeModel::Percentage),
+            "graduated_percentage" => Some(ChargeModel::GraduatedPercentage),
+            "dynamic" => Some(ChargeModel::Dynamic),
+            _ => None,
+        }
+    }
+
+    fn build_charge(charge_args: &CreatePlanChargeArgs) -> Option<CreatePlanChargeInput> {
+        let charge_model = Self::parse_charge_model(&charge_args.charge_model)?;
+
+        let mut charge =
+            CreatePlanChargeInput::new(charge_args.billable_metric_id.clone(), charge_model);
+
+        if let Some(invoiceable) = charge_args.invoiceable {
+            charge = charge.with_invoiceable(invoiceable);
+        }
+        if let Some(name) = &charge_args.invoice_display_name {
+            charge = charge.with_invoice_display_name(name.clone());
+        }
+        if let Some(pay_in_advance) = charge_args.pay_in_advance {
+            charge = charge.with_pay_in_advance(pay_in_advance);
+        }
+        if let Some(prorated) = charge_args.prorated {
+            charge = charge.with_prorated(prorated);
+        }
+        if let Some(min_amount) = charge_args.min_amount_cents {
+            charge = charge.with_min_amount_cents(min_amount);
+        }
+        if let Some(properties) = &charge_args.properties {
+            charge = charge.with_properties(properties.clone());
+        }
+        if let Some(tax_codes) = &charge_args.tax_codes {
+            charge = charge.with_tax_codes(tax_codes.clone());
+        }
+        if let Some(filters) = &charge_args.filters {
+            let filter_inputs: Vec<CreateChargeFilterInput> = filters
+                .iter()
+                .map(|f| CreateChargeFilterInput {
+                    invoice_display_name: f.invoice_display_name.clone(),
+                    properties: f.properties.clone(),
+                    values: f.values.clone(),
+                })
+                .collect();
+            charge = charge.with_filters(filter_inputs);
+        }
+
+        Some(charge)
+    }
+
+    fn build_minimum_commitment(args: &MinimumCommitmentArgs) -> CreateMinimumCommitmentInput {
+        let mut commitment = CreateMinimumCommitmentInput::new(args.amount_cents);
+
+        if let Some(name) = &args.invoice_display_name {
+            commitment = commitment.with_invoice_display_name(name.clone());
+        }
+        if let Some(tax_codes) = &args.tax_codes {
+            commitment = commitment.with_tax_codes(tax_codes.clone());
+        }
+
+        commitment
+    }
+
+    fn build_usage_threshold(args: &UsageThresholdArgs) -> CreateUsageThresholdInput {
+        let mut threshold = CreateUsageThresholdInput::new(args.amount_cents);
+
+        if let Some(name) = &args.threshold_display_name {
+            threshold = threshold.with_threshold_display_name(name.clone());
+        }
+        if let Some(recurring) = args.recurring {
+            threshold = threshold.with_recurring(recurring);
+        }
+
+        threshold
+    }
+
+    pub async fn list_plans(
+        &self,
+        Parameters(args): Parameters<ListPlansArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let client = match create_lago_client(&context).await {
+            Ok(client) => client,
+            Err(error_result) => return Ok(error_result),
+        };
+
+        let mut pagination = PaginationParams::new();
+        if let Some(page) = args.page {
+            pagination = pagination.with_page(page);
+        }
+        if let Some(per_page) = args.per_page {
+            pagination = pagination.with_per_page(per_page);
+        }
+
+        let request = ListPlansRequest::new().with_pagination(pagination);
+
+        match client.list_plans(Some(request)).await {
+            Ok(response) => {
+                let result = serde_json::json!({
+                    "plans": response.plans,
+                    "pagination": response.meta
+                });
+
+                Ok(success_result(&result))
+            }
+            Err(e) => {
+                let error_message = format!("Failed to list plans: {e}");
+                tracing::error!("{error_message}");
+                Ok(error_result(error_message))
+            }
+        }
+    }
+
+    pub async fn get_plan(
+        &self,
+        Parameters(args): Parameters<GetPlanArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let client = match create_lago_client(&context).await {
+            Ok(client) => client,
+            Err(error_result) => return Ok(error_result),
+        };
+
+        let request = GetPlanRequest::new(args.code);
+
+        match client.get_plan(request).await {
+            Ok(response) => {
+                let result = serde_json::json!({
+                    "plan": response.plan,
+                });
+
+                Ok(success_result(&result))
+            }
+            Err(e) => {
+                let error_message = format!("Failed to get plan: {e}");
+                tracing::error!("{error_message}");
+                Ok(error_result(error_message))
+            }
+        }
+    }
+
+    pub async fn create_plan(
+        &self,
+        Parameters(args): Parameters<CreatePlanArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let client = match create_lago_client(&context).await {
+            Ok(client) => client,
+            Err(error_result) => return Ok(error_result),
+        };
+
+        let interval = match Self::parse_interval(&args.interval) {
+            Some(i) => i,
+            None => {
+                return Ok(error_result(format!(
+                    "Invalid interval: {}. Must be one of: weekly, monthly, quarterly, semiannual, yearly",
+                    args.interval
+                )));
+            }
+        };
+
+        let mut input = CreatePlanInput::new(
+            args.name,
+            args.code,
+            interval,
+            args.amount_cents,
+            args.amount_currency,
+        );
+
+        if let Some(name) = args.invoice_display_name {
+            input = input.with_invoice_display_name(name);
+        }
+        if let Some(description) = args.description {
+            input = input.with_description(description);
+        }
+        if let Some(trial_period) = args.trial_period {
+            input = input.with_trial_period(trial_period);
+        }
+        if let Some(pay_in_advance) = args.pay_in_advance {
+            input = input.with_pay_in_advance(pay_in_advance);
+        }
+        if let Some(bill_charges_monthly) = args.bill_charges_monthly {
+            input = input.with_bill_charges_monthly(bill_charges_monthly);
+        }
+        if let Some(tax_codes) = args.tax_codes {
+            input = input.with_tax_codes(tax_codes);
+        }
+        if let Some(charges) = args.charges {
+            let charge_inputs: Vec<CreatePlanChargeInput> =
+                charges.iter().filter_map(Self::build_charge).collect();
+            if !charge_inputs.is_empty() {
+                input = input.with_charges(charge_inputs);
+            }
+        }
+        if let Some(commitment) = args.minimum_commitment {
+            input = input.with_minimum_commitment(Self::build_minimum_commitment(&commitment));
+        }
+        if let Some(thresholds) = args.usage_thresholds {
+            let threshold_inputs: Vec<CreateUsageThresholdInput> =
+                thresholds.iter().map(Self::build_usage_threshold).collect();
+            input = input.with_usage_thresholds(threshold_inputs);
+        }
+
+        let request = CreatePlanRequest::new(input);
+
+        match client.create_plan(request).await {
+            Ok(response) => {
+                let result = serde_json::json!({
+                    "plan": response.plan,
+                });
+
+                Ok(success_result(&result))
+            }
+            Err(e) => {
+                let error_message = format!("Failed to create plan: {e}");
+                tracing::error!("{error_message}");
+                Ok(error_result(error_message))
+            }
+        }
+    }
+
+    pub async fn update_plan(
+        &self,
+        Parameters(args): Parameters<UpdatePlanArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let client = match create_lago_client(&context).await {
+            Ok(client) => client,
+            Err(error_result) => return Ok(error_result),
+        };
+
+        let mut input = UpdatePlanInput::new();
+
+        if let Some(name) = args.name {
+            input = input.with_name(name);
+        }
+        if let Some(code) = args.new_code {
+            input = input.with_code(code);
+        }
+        if let Some(interval_str) = args.interval {
+            if let Some(interval) = Self::parse_interval(&interval_str) {
+                input = input.with_interval(interval);
+            } else {
+                return Ok(error_result(format!(
+                    "Invalid interval: {}. Must be one of: weekly, monthly, quarterly, semiannual, yearly",
+                    interval_str
+                )));
+            }
+        }
+        if let Some(amount_cents) = args.amount_cents {
+            input = input.with_amount_cents(amount_cents);
+        }
+        if let Some(currency) = args.amount_currency {
+            input = input.with_amount_currency(currency);
+        }
+        if let Some(name) = args.invoice_display_name {
+            input = input.with_invoice_display_name(name);
+        }
+        if let Some(description) = args.description {
+            input = input.with_description(description);
+        }
+        if let Some(trial_period) = args.trial_period {
+            input = input.with_trial_period(trial_period);
+        }
+        if let Some(pay_in_advance) = args.pay_in_advance {
+            input = input.with_pay_in_advance(pay_in_advance);
+        }
+        if let Some(bill_charges_monthly) = args.bill_charges_monthly {
+            input = input.with_bill_charges_monthly(bill_charges_monthly);
+        }
+        if let Some(tax_codes) = args.tax_codes {
+            input = input.with_tax_codes(tax_codes);
+        }
+        if let Some(charges) = args.charges {
+            let charge_inputs: Vec<CreatePlanChargeInput> =
+                charges.iter().filter_map(Self::build_charge).collect();
+            if !charge_inputs.is_empty() {
+                input = input.with_charges(charge_inputs);
+            }
+        }
+        if let Some(commitment) = args.minimum_commitment {
+            input = input.with_minimum_commitment(Self::build_minimum_commitment(&commitment));
+        }
+        if let Some(thresholds) = args.usage_thresholds {
+            let threshold_inputs: Vec<CreateUsageThresholdInput> =
+                thresholds.iter().map(Self::build_usage_threshold).collect();
+            input = input.with_usage_thresholds(threshold_inputs);
+        }
+        if let Some(cascade_updates) = args.cascade_updates {
+            input = input.with_cascade_updates(cascade_updates);
+        }
+
+        let request = UpdatePlanRequest::new(args.code, input);
+
+        match client.update_plan(request).await {
+            Ok(response) => {
+                let result = serde_json::json!({
+                    "plan": response.plan,
+                });
+
+                Ok(success_result(&result))
+            }
+            Err(e) => {
+                let error_message = format!("Failed to update plan: {e}");
+                tracing::error!("{error_message}");
+                Ok(error_result(error_message))
+            }
+        }
+    }
+
+    pub async fn delete_plan(
+        &self,
+        Parameters(args): Parameters<DeletePlanArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let client = match create_lago_client(&context).await {
+            Ok(client) => client,
+            Err(error_result) => return Ok(error_result),
+        };
+
+        let request = DeletePlanRequest::new(args.code);
+
+        match client.delete_plan(request).await {
+            Ok(response) => {
+                let result = serde_json::json!({
+                    "plan": response.plan,
+                });
+
+                Ok(success_result(&result))
+            }
+            Err(e) => {
+                let error_message = format!("Failed to delete plan: {e}");
+                tracing::error!("{error_message}");
+                Ok(error_result(error_message))
+            }
+        }
+    }
+}

--- a/mcp/src/tools/subscription.rs
+++ b/mcp/src/tools/subscription.rs
@@ -1,0 +1,425 @@
+use anyhow::Result;
+use rmcp::{RoleServer, handler::server::tool::Parameters, model::*, service::RequestContext};
+use serde::{Deserialize, Serialize};
+
+use lago_types::{
+    filters::subscription::SubscriptionFilters,
+    models::{PaginationParams, SubscriptionBillingTime, SubscriptionStatus},
+    requests::subscription::{
+        CreateSubscriptionInput, CreateSubscriptionRequest, DeleteSubscriptionRequest,
+        GetSubscriptionRequest, ListCustomerSubscriptionsRequest, ListSubscriptionsRequest,
+        SubscriptionPlanOverrides, UpdateSubscriptionInput, UpdateSubscriptionRequest,
+    },
+};
+
+use crate::tools::{create_lago_client, error_result, success_result};
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct ListSubscriptionsArgs {
+    /// Filter by plan code.
+    pub plan_code: Option<String>,
+    /// Filter by subscription status. Possible values: active, pending, canceled, terminated.
+    pub status: Option<Vec<String>>,
+    /// Page number for pagination (default: 1).
+    pub page: Option<i32>,
+    /// Number of items per page (default: 20).
+    pub per_page: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct GetSubscriptionArgs {
+    /// The external unique identifier of the subscription.
+    pub external_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct ListCustomerSubscriptionsArgs {
+    /// The external unique identifier of the customer.
+    pub external_customer_id: String,
+    /// Filter by plan code.
+    pub plan_code: Option<String>,
+    /// Filter by subscription status. Possible values: active, pending, canceled, terminated.
+    pub status: Option<Vec<String>>,
+    /// Page number for pagination (default: 1).
+    pub page: Option<i32>,
+    /// Number of items per page (default: 20).
+    pub per_page: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct CreateSubscriptionArgs {
+    /// External unique identifier for the customer.
+    pub external_customer_id: String,
+    /// Code of the plan to assign to the subscription.
+    pub plan_code: String,
+    /// Optional display name for the subscription.
+    pub name: Option<String>,
+    /// Optional external unique identifier for the subscription.
+    pub external_id: Option<String>,
+    /// Billing time determines when recurring billing cycles occur. Possible values: anniversary, calendar.
+    pub billing_time: Option<String>,
+    /// The subscription start date (ISO 8601 format).
+    pub subscription_at: Option<String>,
+    /// The subscription end date (ISO 8601 format).
+    pub ending_at: Option<String>,
+    /// Plan overrides to customize the plan for this subscription.
+    pub plan_overrides: Option<PlanOverridesInput>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct PlanOverridesInput {
+    /// Override the base amount in cents.
+    pub amount_cents: Option<i64>,
+    /// Override the currency.
+    pub amount_currency: Option<String>,
+    /// Override the plan description.
+    pub description: Option<String>,
+    /// Override the invoice display name.
+    pub invoice_display_name: Option<String>,
+    /// Override the plan name.
+    pub name: Option<String>,
+    /// Override the trial period in days.
+    pub trial_period: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct UpdateSubscriptionArgs {
+    /// The external unique identifier of the subscription to update.
+    pub external_id: String,
+    /// Optional new name for the subscription.
+    pub name: Option<String>,
+    /// Optional new end date for the subscription (ISO 8601 format).
+    pub ending_at: Option<String>,
+    /// Optional new plan code (for plan changes).
+    pub plan_code: Option<String>,
+    /// Optional new subscription date (ISO 8601 format).
+    pub subscription_at: Option<String>,
+    /// Plan overrides to customize the plan for this subscription.
+    pub plan_overrides: Option<PlanOverridesInput>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct DeleteSubscriptionArgs {
+    /// The external unique identifier of the subscription to terminate.
+    pub external_id: String,
+    /// Optional status to set the subscription to (defaults to terminated).
+    pub status: Option<String>,
+}
+
+#[derive(Clone)]
+pub struct SubscriptionService;
+
+impl SubscriptionService {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn parse_status(status_str: &str) -> Option<SubscriptionStatus> {
+        match status_str.to_lowercase().as_str() {
+            "active" => Some(SubscriptionStatus::Active),
+            "pending" => Some(SubscriptionStatus::Pending),
+            "canceled" => Some(SubscriptionStatus::Canceled),
+            "terminated" => Some(SubscriptionStatus::Terminated),
+            _ => None,
+        }
+    }
+
+    fn parse_billing_time(billing_time_str: &str) -> Option<SubscriptionBillingTime> {
+        match billing_time_str.to_lowercase().as_str() {
+            "anniversary" => Some(SubscriptionBillingTime::Anniversary),
+            "calendar" => Some(SubscriptionBillingTime::Calendar),
+            _ => None,
+        }
+    }
+
+    fn build_filters(
+        plan_code: Option<String>,
+        status: Option<Vec<String>>,
+    ) -> SubscriptionFilters {
+        let mut filters = SubscriptionFilters::new();
+
+        if let Some(plan_code) = plan_code {
+            filters = filters.with_plan_code(plan_code);
+        }
+
+        if let Some(statuses) = status {
+            let parsed_statuses: Vec<SubscriptionStatus> = statuses
+                .iter()
+                .filter_map(|s| Self::parse_status(s))
+                .collect();
+            if !parsed_statuses.is_empty() {
+                filters = filters.with_statuses(parsed_statuses);
+            }
+        }
+
+        filters
+    }
+
+    fn build_plan_overrides(
+        input: Option<PlanOverridesInput>,
+    ) -> Option<SubscriptionPlanOverrides> {
+        input.map(|overrides| {
+            let mut plan_overrides = SubscriptionPlanOverrides::new();
+
+            if let Some(amount_cents) = overrides.amount_cents {
+                plan_overrides = plan_overrides.with_amount_cents(amount_cents);
+            }
+            if let Some(currency) = overrides.amount_currency {
+                plan_overrides = plan_overrides.with_amount_currency(currency);
+            }
+            if let Some(description) = overrides.description {
+                plan_overrides = plan_overrides.with_description(description);
+            }
+            if let Some(invoice_display_name) = overrides.invoice_display_name {
+                plan_overrides = plan_overrides.with_invoice_display_name(invoice_display_name);
+            }
+            if let Some(name) = overrides.name {
+                plan_overrides = plan_overrides.with_name(name);
+            }
+            if let Some(trial_period) = overrides.trial_period {
+                plan_overrides = plan_overrides.with_trial_period(trial_period);
+            }
+
+            plan_overrides
+        })
+    }
+
+    pub async fn list_subscriptions(
+        &self,
+        Parameters(args): Parameters<ListSubscriptionsArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let client = match create_lago_client(&context).await {
+            Ok(client) => client,
+            Err(error_result) => return Ok(error_result),
+        };
+
+        let filters = Self::build_filters(args.plan_code, args.status);
+
+        let mut pagination = PaginationParams::new();
+        if let Some(page) = args.page {
+            pagination = pagination.with_page(page);
+        }
+        if let Some(per_page) = args.per_page {
+            pagination = pagination.with_per_page(per_page);
+        }
+
+        let request = ListSubscriptionsRequest::new()
+            .with_filters(filters)
+            .with_pagination(pagination);
+
+        match client.list_subscriptions(Some(request)).await {
+            Ok(response) => {
+                let result = serde_json::json!({
+                    "subscriptions": response.subscriptions,
+                    "pagination": response.meta
+                });
+
+                Ok(success_result(&result))
+            }
+            Err(e) => {
+                let error_message = format!("Failed to list subscriptions: {e}");
+                tracing::error!("{error_message}");
+                Ok(error_result(error_message))
+            }
+        }
+    }
+
+    pub async fn get_subscription(
+        &self,
+        Parameters(args): Parameters<GetSubscriptionArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let client = match create_lago_client(&context).await {
+            Ok(client) => client,
+            Err(error_result) => return Ok(error_result),
+        };
+
+        let request = GetSubscriptionRequest::new(args.external_id);
+
+        match client.get_subscription(request).await {
+            Ok(response) => {
+                let result = serde_json::json!({
+                    "subscription": response.subscription,
+                });
+
+                Ok(success_result(&result))
+            }
+            Err(e) => {
+                let error_message = format!("Failed to get subscription: {e}");
+                tracing::error!("{error_message}");
+                Ok(error_result(error_message))
+            }
+        }
+    }
+
+    pub async fn list_customer_subscriptions(
+        &self,
+        Parameters(args): Parameters<ListCustomerSubscriptionsArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let client = match create_lago_client(&context).await {
+            Ok(client) => client,
+            Err(error_result) => return Ok(error_result),
+        };
+
+        let filters = Self::build_filters(args.plan_code, args.status);
+
+        let mut pagination = PaginationParams::new();
+        if let Some(page) = args.page {
+            pagination = pagination.with_page(page);
+        }
+        if let Some(per_page) = args.per_page {
+            pagination = pagination.with_per_page(per_page);
+        }
+
+        let request = ListCustomerSubscriptionsRequest::new(args.external_customer_id)
+            .with_filters(filters)
+            .with_pagination(pagination);
+
+        match client.list_customer_subscriptions(request).await {
+            Ok(response) => {
+                let result = serde_json::json!({
+                    "subscriptions": response.subscriptions,
+                    "pagination": response.meta
+                });
+
+                Ok(success_result(&result))
+            }
+            Err(e) => {
+                let error_message = format!("Failed to list customer subscriptions: {e}");
+                tracing::error!("{error_message}");
+                Ok(error_result(error_message))
+            }
+        }
+    }
+
+    pub async fn create_subscription(
+        &self,
+        Parameters(args): Parameters<CreateSubscriptionArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let client = match create_lago_client(&context).await {
+            Ok(client) => client,
+            Err(error_result) => return Ok(error_result),
+        };
+
+        let mut input = CreateSubscriptionInput::new(args.external_customer_id, args.plan_code);
+
+        if let Some(name) = args.name {
+            input = input.with_name(name);
+        }
+        if let Some(external_id) = args.external_id {
+            input = input.with_external_id(external_id);
+        }
+        if let Some(billing_time_str) = args.billing_time
+            && let Some(billing_time) = Self::parse_billing_time(&billing_time_str)
+        {
+            input = input.with_billing_time(billing_time);
+        }
+        if let Some(subscription_at) = args.subscription_at {
+            input = input.with_subscription_at(subscription_at);
+        }
+        if let Some(ending_at) = args.ending_at {
+            input = input.with_ending_at(ending_at);
+        }
+        if let Some(plan_overrides) = Self::build_plan_overrides(args.plan_overrides) {
+            input = input.with_plan_overrides(plan_overrides);
+        }
+
+        let request = CreateSubscriptionRequest::new(input);
+
+        match client.create_subscription(request).await {
+            Ok(response) => {
+                let result = serde_json::json!({
+                    "subscription": response.subscription,
+                });
+
+                Ok(success_result(&result))
+            }
+            Err(e) => {
+                let error_message = format!("Failed to create subscription: {e}");
+                tracing::error!("{error_message}");
+                Ok(error_result(error_message))
+            }
+        }
+    }
+
+    pub async fn update_subscription(
+        &self,
+        Parameters(args): Parameters<UpdateSubscriptionArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let client = match create_lago_client(&context).await {
+            Ok(client) => client,
+            Err(error_result) => return Ok(error_result),
+        };
+
+        let mut input = UpdateSubscriptionInput::new();
+
+        if let Some(name) = args.name {
+            input = input.with_name(name);
+        }
+        if let Some(ending_at) = args.ending_at {
+            input = input.with_ending_at(ending_at);
+        }
+        if let Some(plan_code) = args.plan_code {
+            input = input.with_plan_code(plan_code);
+        }
+        if let Some(subscription_at) = args.subscription_at {
+            input = input.with_subscription_at(subscription_at);
+        }
+        if let Some(plan_overrides) = Self::build_plan_overrides(args.plan_overrides) {
+            input = input.with_plan_overrides(plan_overrides);
+        }
+
+        let request = UpdateSubscriptionRequest::new(args.external_id, input);
+
+        match client.update_subscription(request).await {
+            Ok(response) => {
+                let result = serde_json::json!({
+                    "subscription": response.subscription,
+                });
+
+                Ok(success_result(&result))
+            }
+            Err(e) => {
+                let error_message = format!("Failed to update subscription: {e}");
+                tracing::error!("{error_message}");
+                Ok(error_result(error_message))
+            }
+        }
+    }
+
+    pub async fn delete_subscription(
+        &self,
+        Parameters(args): Parameters<DeleteSubscriptionArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let client = match create_lago_client(&context).await {
+            Ok(client) => client,
+            Err(error_result) => return Ok(error_result),
+        };
+
+        let mut request = DeleteSubscriptionRequest::new(args.external_id);
+
+        if let Some(status) = args.status {
+            request = request.with_status(status);
+        }
+
+        match client.delete_subscription(request).await {
+            Ok(response) => {
+                let result = serde_json::json!({
+                    "subscription": response.subscription,
+                });
+
+                Ok(success_result(&result))
+            }
+            Err(e) => {
+                let error_message = format!("Failed to delete subscription: {e}");
+                tracing::error!("{error_message}");
+                Ok(error_result(error_message))
+            }
+        }
+    }
+}


### PR DESCRIPTION
The goal of this PR is to:
- add support of subscription
- add support of plan
- add support of customer usage
- bump lago-types to 0.1.13
- bump lago-client to 0.1.13