### PR TITLE
Update README to remove MISTRAL environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ Add this configuration to your Claude Desktop MCP settings:
         "--name", "lago-mcp-server",
         "-e", "LAGO_API_KEY=your_lago_api_key",
         "-e", "LAGO_API_URL=https://api.getlago.com/api/v1",
-        "-e", "MISTRAL_AGENT_ID=your_mistral_agent_id",
-        "-e", "MISTRAL_API_KEY=your_mistral_api_key",
         "getlago/lago-mcp-server:latest"
       ]
     }


### PR DESCRIPTION
Removed MISTRAL_AGENT_ID and MISTRAL_API_KEY environment variables from the README.