### PR TITLE
feat(invoice): Add `void_invoice` tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Once configured, you can ask Claude natural language questions about your billin
 - **`download_invoice`**: Download an invoice PDF
 - **`retry_invoice`**: Retry generation of a failed invoice
 - **`retry_invoice_payment`**: Retry payment collection for an invoice
+- **`void_invoice`**: Void a finalized invoice to prevent further modifications or payments
 
 ### Customers
 - **`get_customer`**: Retrieve a customer by external ID

--- a/mcp/Cargo.lock
+++ b/mcp/Cargo.lock
@@ -915,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "lago-client"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72bea4fc67f962c73fabed3a91abee4a77ff93cd4391ed50e4dab8a69517334a"
+checksum = "8a87455e40d7f445f34f60a2e107de33b2e24a3ab9e2ebd81d0d8d25f36e431b"
 dependencies = [
  "anyhow",
  "lago-types",
@@ -955,9 +955,9 @@ dependencies = [
 
 [[package]]
 name = "lago-types"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d737524f876e20d6d7f58be339724d69de511e04c2237ce03959f2a457e1e7f"
+checksum = "32332cbc7b35e33e0bf88ce08b14841edf35f9726966e676f8cafa4f91b942ab"
 dependencies = [
  "chrono",
  "reqwest",

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -23,8 +23,8 @@ async-trait = "0.1"
 schemars = { version = "1.0", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-lago-client = "0.1.17"
-lago-types = "0.1.17"
+lago-client = "0.1.18"
+lago-types = "0.1.18"
 clap = { version = "4.5", features = ["derive"] }
 tokio-util = "0.7"
 axum = { version = "0.8", features = ["macros"] }

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -205,6 +205,17 @@ impl LagoMcpServer {
             .await
     }
 
+    #[tool(
+        description = "Void a finalized invoice. This changes the invoice status to 'voided' and prevents further modifications or payments. Only finalized invoices can be voided."
+    )]
+    pub async fn void_invoice(
+        &self,
+        parameters: Parameters<crate::tools::invoice::VoidInvoiceArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        self.invoice_service.void_invoice(parameters, context).await
+    }
+
     #[tool(description = "Get a specific customer by their external ID")]
     pub async fn get_customer(
         &self,


### PR DESCRIPTION
Add support for voiding finalized invoices via the MCP server. This tool allows AI assistants to void invoices, changing their status to `voided` and preventing further modifications or payments.

Note: Requires `lago-client` and `lago-types` version `0.1.18`, which includes the `VoidInvoiceRequest` and `void_invoice` client method.