### PR TITLE
fix(event): Fix UUID deserialization error in event tools

### DIFF
--- a/mcp/Cargo.lock
+++ b/mcp/Cargo.lock
@@ -941,6 +941,7 @@ dependencies = [
  "clap",
  "lago-client",
  "lago-types",
+ "reqwest",
  "rmcp",
  "schemars",
  "serde",
@@ -950,6 +951,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "urlencoding",
  "uuid",
 ]
 

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -25,6 +25,8 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 lago-client = "0.1.20"
 lago-types = "0.1.20"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+urlencoding = "2.1"
 clap = { version = "4.5", features = ["derive"] }
 tokio-util = "0.7"
 axum = { version = "0.8", features = ["macros"] }

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -32,4 +32,4 @@ USER appuser
 
 ENV RUST_LOG=info
 
-CMD ["./lago-mcp-server","sse"]
+CMD ["./lago-mcp-server","stdio"]

--- a/mcp/src/tools.rs
+++ b/mcp/src/tools.rs
@@ -12,7 +12,9 @@ pub mod payment;
 pub mod plan;
 pub mod subscription;
 
-use lago_client::{Config, Credentials, EnvironmentRegionProvider, LagoClient, Region, RegionProvider};
+use lago_client::{
+    Config, Credentials, EnvironmentRegionProvider, LagoClient, Region, RegionProvider,
+};
 use rmcp::{
     RoleServer,
     model::{CallToolResult, Content},
@@ -50,9 +52,8 @@ pub async fn get_lago_api_config(
         });
     }
 
-    let api_key = env::var("LAGO_API_KEY").map_err(|_| {
-        error_result("LAGO_API_KEY environment variable not set")
-    })?;
+    let api_key = env::var("LAGO_API_KEY")
+        .map_err(|_| error_result("LAGO_API_KEY environment variable not set"))?;
     let region = EnvironmentRegionProvider::new()
         .provider_region()
         .map_err(|e| error_result(format!("Failed to resolve region: {e}")))?;

--- a/mcp/src/tools.rs
+++ b/mcp/src/tools.rs
@@ -21,6 +21,45 @@ use rmcp::{
 use serde::Serialize;
 use std::env;
 
+pub struct LagoApiConfig {
+    pub api_key: String,
+    pub base_url: String,
+}
+
+pub async fn get_lago_api_config(
+    context: &RequestContext<RoleServer>,
+) -> Result<LagoApiConfig, CallToolResult> {
+    let (header_key, header_url) = context
+        .extensions
+        .get::<axum::http::request::Parts>()
+        .map(|parts| {
+            let key = parts
+                .headers
+                .get("X-LAGO-API-KEY")
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_string());
+            let url = env::var("LAGO_API_URL").ok();
+            (key, url)
+        })
+        .unwrap_or((None, None));
+
+    if let (Some(key), Some(url)) = (header_key, header_url) {
+        return Ok(LagoApiConfig {
+            api_key: key,
+            base_url: url,
+        });
+    }
+
+    let api_key = env::var("LAGO_API_KEY").map_err(|_| {
+        error_result("LAGO_API_KEY environment variable not set")
+    })?;
+    let base_url = env::var("LAGO_API_URL").unwrap_or_else(|_| {
+        "https://api.getlago.com/api/v1".to_string()
+    });
+
+    Ok(LagoApiConfig { api_key, base_url })
+}
+
 pub async fn create_lago_client(
     context: &RequestContext<RoleServer>,
 ) -> Result<LagoClient, CallToolResult> {

--- a/mcp/src/tools.rs
+++ b/mcp/src/tools.rs
@@ -12,7 +12,7 @@ pub mod payment;
 pub mod plan;
 pub mod subscription;
 
-use lago_client::{Config, Credentials, LagoClient, Region};
+use lago_client::{Config, Credentials, EnvironmentRegionProvider, LagoClient, Region, RegionProvider};
 use rmcp::{
     RoleServer,
     model::{CallToolResult, Content},
@@ -53,9 +53,10 @@ pub async fn get_lago_api_config(
     let api_key = env::var("LAGO_API_KEY").map_err(|_| {
         error_result("LAGO_API_KEY environment variable not set")
     })?;
-    let base_url = env::var("LAGO_API_URL").unwrap_or_else(|_| {
-        "https://api.getlago.com/api/v1".to_string()
-    });
+    let region = EnvironmentRegionProvider::new()
+        .provider_region()
+        .map_err(|e| error_result(format!("Failed to resolve region: {e}")))?;
+    let base_url = region.endpoint().to_string();
 
     Ok(LagoApiConfig { api_key, base_url })
 }

--- a/mcp/src/tools/event.rs
+++ b/mcp/src/tools/event.rs
@@ -100,8 +100,7 @@ impl EventService {
                     .text()
                     .await
                     .unwrap_or_else(|_| "Unknown error".to_string());
-                let error_message =
-                    format!("Failed to get event (HTTP {status}): {body}");
+                let error_message = format!("Failed to get event (HTTP {status}): {body}");
                 tracing::error!(
                     transaction_id = %args.transaction_id,
                     "{error_message}"
@@ -253,8 +252,7 @@ impl EventService {
                     .text()
                     .await
                     .unwrap_or_else(|_| "Unknown error".to_string());
-                let error_message =
-                    format!("Failed to list events (HTTP {status}): {body}");
+                let error_message = format!("Failed to list events (HTTP {status}): {body}");
                 tracing::error!("{error_message}");
                 Ok(error_result(error_message))
             }

--- a/mcp/src/tools/event.rs
+++ b/mcp/src/tools/event.rs
@@ -1,14 +1,10 @@
-use anyhow::Result;
 use rmcp::{RoleServer, handler::server::tool::Parameters, model::*, service::RequestContext};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use lago_types::{
-    models::PaginationParams,
-    requests::event::{CreateEventInput, CreateEventRequest, GetEventRequest, ListEventsRequest},
-};
+use lago_types::requests::event::{CreateEventInput, CreateEventRequest};
 
-use crate::tools::{create_lago_client, error_result, success_result};
+use crate::tools::{create_lago_client, error_result, get_lago_api_config, success_result};
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct ListEventsArgs {
@@ -53,11 +49,15 @@ pub struct CreateEventArgs {
 }
 
 #[derive(Clone)]
-pub struct EventService;
+pub struct EventService {
+    http_client: reqwest::Client,
+}
 
 impl EventService {
     pub fn new() -> Self {
-        Self
+        Self {
+            http_client: reqwest::Client::new(),
+        }
     }
 
     pub async fn get_event(
@@ -65,20 +65,48 @@ impl EventService {
         Parameters(args): Parameters<GetEventArgs>,
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
-        let client = match create_lago_client(&context).await {
-            Ok(client) => client,
+        let config = match get_lago_api_config(&context).await {
+            Ok(config) => config,
             Err(error_result) => return Ok(error_result),
         };
 
-        let request = GetEventRequest::new(args.transaction_id.clone());
+        let encoded_id = urlencoding::encode(&args.transaction_id);
+        let url = format!("{}/events/{}", config.base_url, encoded_id);
 
-        match client.get_event(request).await {
+        match self
+            .http_client
+            .get(&url)
+            .bearer_auth(&config.api_key)
+            .send()
+            .await
+        {
+            Ok(response) if response.status().is_success() => {
+                match response.json::<Value>().await {
+                    Ok(json) => Ok(success_result(&json)),
+                    Err(e) => {
+                        let error_message = format!("Failed to parse event response: {e}");
+                        tracing::error!(
+                            transaction_id = %args.transaction_id,
+                            error = %e,
+                            "{error_message}"
+                        );
+                        Ok(error_result(error_message))
+                    }
+                }
+            }
             Ok(response) => {
-                let result = serde_json::json!({
-                    "event": response.event,
-                });
-
-                Ok(success_result(&result))
+                let status = response.status();
+                let body = response
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| "Unknown error".to_string());
+                let error_message =
+                    format!("Failed to get event (HTTP {status}): {body}");
+                tracing::error!(
+                    transaction_id = %args.transaction_id,
+                    "{error_message}"
+                );
+                Ok(error_result(error_message))
             }
             Err(e) => {
                 let error_message = format!("Failed to get event: {e}");
@@ -167,49 +195,68 @@ impl EventService {
         Parameters(args): Parameters<ListEventsArgs>,
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
-        let client = match create_lago_client(&context).await {
-            Ok(client) => client,
+        let config = match get_lago_api_config(&context).await {
+            Ok(config) => config,
             Err(error_result) => return Ok(error_result),
         };
 
-        let mut pagination = PaginationParams::new();
+        let mut params: Vec<(&str, String)> = Vec::new();
+
         if let Some(page) = args.page {
-            pagination = pagination.with_page(page);
+            params.push(("page", page.to_string()));
         }
         if let Some(per_page) = args.per_page {
-            pagination = pagination.with_per_page(per_page);
+            params.push(("per_page", per_page.to_string()));
         }
-
-        let mut request = ListEventsRequest::new().with_pagination(pagination);
-
-        if let Some(external_subscription_id) = args.external_subscription_id {
-            request = request.with_external_subscription_id(external_subscription_id);
+        if let Some(ref external_subscription_id) = args.external_subscription_id {
+            params.push(("external_subscription_id", external_subscription_id.clone()));
         }
-
-        if let Some(code) = args.code {
-            request = request.with_code(code);
+        if let Some(ref code) = args.code {
+            params.push(("code", code.clone()));
         }
-
         if let Some(timestamp_from_started_at) = args.timestamp_from_started_at {
-            request = request.with_timestamp_from_started_at(timestamp_from_started_at);
+            params.push((
+                "timestamp_from_started_at",
+                timestamp_from_started_at.to_string(),
+            ));
+        }
+        if let Some(ref timestamp_from) = args.timestamp_from {
+            params.push(("timestamp_from", timestamp_from.clone()));
+        }
+        if let Some(ref timestamp_to) = args.timestamp_to {
+            params.push(("timestamp_to", timestamp_to.clone()));
         }
 
-        if let Some(timestamp_from) = args.timestamp_from {
-            request = request.with_timestamp_from(timestamp_from);
-        }
+        let url = format!("{}/events", config.base_url);
 
-        if let Some(timestamp_to) = args.timestamp_to {
-            request = request.with_timestamp_to(timestamp_to);
-        }
-
-        match client.list_events(Some(request)).await {
+        match self
+            .http_client
+            .get(&url)
+            .bearer_auth(&config.api_key)
+            .query(&params)
+            .send()
+            .await
+        {
+            Ok(response) if response.status().is_success() => {
+                match response.json::<Value>().await {
+                    Ok(json) => Ok(success_result(&json)),
+                    Err(e) => {
+                        let error_message = format!("Failed to parse events response: {e}");
+                        tracing::error!("{error_message}");
+                        Ok(error_result(error_message))
+                    }
+                }
+            }
             Ok(response) => {
-                let result = serde_json::json!({
-                    "events": response.events,
-                    "pagination": response.meta
-                });
-
-                Ok(success_result(&result))
+                let status = response.status();
+                let body = response
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| "Unknown error".to_string());
+                let error_message =
+                    format!("Failed to list events (HTTP {status}): {body}");
+                tracing::error!("{error_message}");
+                Ok(error_result(error_message))
             }
             Err(e) => {
                 let error_message = format!("Failed to list events: {e}");


### PR DESCRIPTION
## Summary

- **Fix event tool deserialization bug**: `list_events` and `get_event` failed with a serialization error because `lago-types` v0.1.20 defines `Event.lago_id` as `Uuid` (non-optional), but the Lago API can return values that fail UUID parsing. Bypassed the typed client for event read operations using raw `reqwest` + `serde_json::Value` deserialization.
- **Fix Dockerfile CMD**: Changed default from `sse` to `stdio` — the Docker Hub image was built before this change and used `stdio`. Rebuilding without this fix breaks Claude Desktop (which communicates via stdio).
- **Added `reqwest` and `urlencoding`** as direct dependencies for the raw HTTP workaround.

## Root cause

The `lago-types` crate (v0.1.20) `Event` model at `src/models/event.rs:13`:
```rust
pub lago_id: Uuid,  // non-optional — fails on non-UUID values
```
Compare with `Invoice` which uses `Option<Uuid>`. The typed `lago-client` deserializes API responses directly into this struct, so any non-UUID `lago_id` causes a `Serialization` error that makes `list_events` and `get_event` completely unusable.

## Changes

| File | Change |
|------|--------|
| `mcp/Cargo.toml` | Added `reqwest` (rustls-tls, json) and `urlencoding` |
| `mcp/Dockerfile` | CMD `sse` → `stdio` |
| `mcp/src/tools.rs` | Added `LagoApiConfig` struct + `get_lago_api_config()` helper |
| `mcp/src/tools/event.rs` | `list_events` and `get_event` use raw HTTP; `create_event` unchanged |

## Security review

A full security review was conducted on all changes. **No vulnerabilities found.**

| Area | File | Status |
|------|------|--------|
| Path traversal via `transaction_id` | `event.rs:73-74` | ✅ Mitigated — `urlencoding::encode()` encodes `/`, `..`, `%` |
| Query parameter injection | `event.rs:203-237` | ✅ Mitigated — reqwest `.query()` handles encoding |
| SSRF via `base_url` | `tools.rs:41,56-57` | ✅ Safe — `base_url` sourced only from env vars |
| Auth credential handling | `tools.rs:29-61` | ✅ Mirrors existing `create_lago_client()` pattern |
| Untyped response pass-through | `event.rs:83-85` | ✅ Data scoped to caller's own API key |

## Test plan

- [x] `docker build` succeeds with no warnings
- [x] Docker image CMD is `stdio` (verified via `docker inspect`)
- [x] Restart Claude Desktop → confirm `lago:list_events`, `lago:get_event`, `lago:create_event` appear
- [x] Run `list_events` — should return events without serialization error
- [x] Run `get_event` with a known `transaction_id`
- [x] Run `create_event` — should still work (unchanged code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)