### PR TITLE
refactor(billable_metric): Use lago-client for update_billable_metric

### DIFF
--- a/mcp/Cargo.lock
+++ b/mcp/Cargo.lock
@@ -915,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "lago-client"
-version = "0.1.20"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1bc17fe47cbbe6f6e7f1ec63acef50c630fdff227d01f40a9cb497571a83578"
+checksum = "1666f882dfdb387c20f8216902cff13138dbafb9f229ec3c5d9f6982bdd0fceb"
 dependencies = [
  "anyhow",
  "lago-types",
@@ -957,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "lago-types"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f65658594803e57c0696f7ad13aa95cfe806f493e03841bf2c97ee599fa3cb3"
+checksum = "95cbc412f63d7cf30c04cc81bc4fe4ee1bf5efe3ce4adb889c23b0673f17e6a3"
 dependencies = [
  "chrono",
  "reqwest",
@@ -1542,9 +1542,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -23,8 +23,8 @@ async-trait = "0.1"
 schemars = { version = "1.0", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-lago-client = "0.1.20"
-lago-types = "0.1.20"
+lago-client = "0.1.23"
+lago-types = "0.1.21"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 urlencoding = "2.1"
 clap = { version = "4.5", features = ["derive"] }

--- a/mcp/src/main.rs
+++ b/mcp/src/main.rs
@@ -70,7 +70,7 @@ async fn main() -> Result<()> {
             let router = axum::Router::new()
                 .nest_service("/mcp", service)
                 .route("/health", axum::routing::get(|| async {}));
-            let address = format!("{}:{}", host, port);
+            let address = format!("{host}:{port}");
             let tcp_listener = tokio::net::TcpListener::bind(address).await?;
             let _ = axum::serve(tcp_listener, router)
                 .with_graceful_shutdown(async { tokio::signal::ctrl_c().await.unwrap() })

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -388,6 +388,17 @@ impl LagoMcpServer {
             .await
     }
 
+    #[tool(description = "Update an existing billable metric in Lago by its code")]
+    pub async fn update_billable_metric(
+        &self,
+        parameters: Parameters<crate::tools::billable_metric::UpdateBillableMetricArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        self.billable_metric_service
+            .update_billable_metric(parameters, context)
+            .await
+    }
+
     #[tool(description = "Get a specific activity log by its activity ID")]
     pub async fn get_activity_log(
         &self,

--- a/mcp/src/tools/billable_metric.rs
+++ b/mcp/src/tools/billable_metric.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use rmcp::{RoleServer, handler::server::tool::Parameters, model::*, service::RequestContext};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use lago_types::{
     filters::billable_metric::BillableMetricFilter,
@@ -14,7 +15,7 @@ use lago_types::{
     },
 };
 
-use crate::tools::{create_lago_client, error_result, success_result};
+use crate::tools::{create_lago_client, error_result, get_lago_api_config, success_result};
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct ListBillableMetricsArgs {
@@ -45,17 +46,47 @@ pub struct CreateBillableMetricArgs {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct UpdateBillableMetricArgs {
+    /// The code of the billable metric to update.
+    pub code: String,
+    /// New name of the billable metric.
+    pub name: Option<String>,
+    /// New code for the billable metric.
+    pub new_code: Option<String>,
+    /// New description for the billable metric.
+    pub description: Option<String>,
+    /// Whether the metric persists across billing periods.
+    pub recurring: Option<bool>,
+    /// Rounding function. Possible values: round, ceil, floor.
+    pub rounding_function: Option<String>,
+    /// Number of decimal places for rounding.
+    pub rounding_precision: Option<i32>,
+    /// Expression used to calculate event units.
+    pub expression: Option<String>,
+    /// The property to aggregate on.
+    pub field_name: Option<String>,
+    /// Weighted interval for weighted_sum_agg. Possible values: seconds.
+    pub weighted_interval: Option<String>,
+    /// Filters for differentiated pricing.
+    pub filters: Option<Vec<BillableMetricFilterInput>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct BillableMetricFilterInput {
     pub key: String,
     pub values: Vec<String>,
 }
 
 #[derive(Clone)]
-pub struct BillableMetricService;
+pub struct BillableMetricService {
+    http_client: reqwest::Client,
+}
 
 impl BillableMetricService {
     pub fn new() -> Self {
-        Self
+        Self {
+            http_client: reqwest::Client::new(),
+        }
     }
 
     #[allow(clippy::collapsible_if)]
@@ -224,6 +255,137 @@ impl BillableMetricService {
             Err(e) => {
                 let error_message = format!("Failed to create billable metric: {e}");
                 tracing::error!("{error_message}");
+                Ok(error_result(error_message))
+            }
+        }
+    }
+
+    pub async fn update_billable_metric(
+        &self,
+        Parameters(args): Parameters<UpdateBillableMetricArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let config = match get_lago_api_config(&context).await {
+            Ok(config) => config,
+            Err(error_result) => return Ok(error_result),
+        };
+
+        let mut body = serde_json::Map::new();
+
+        if let Some(name) = args.name {
+            body.insert("name".into(), Value::String(name));
+        }
+        if let Some(new_code) = args.new_code {
+            body.insert("code".into(), Value::String(new_code));
+        }
+        if let Some(description) = args.description {
+            body.insert("description".into(), Value::String(description));
+        }
+        if let Some(recurring) = args.recurring {
+            body.insert("recurring".into(), Value::Bool(recurring));
+        }
+        if let Some(rounding_function_str) = args.rounding_function {
+            if rounding_function_str
+                .parse::<BillableMetricRoundingFunction>()
+                .is_err()
+            {
+                return Ok(error_result(format!(
+                    "Invalid rounding_function: {rounding_function_str}. Valid values are: round, ceil, floor"
+                )));
+            }
+            body.insert(
+                "rounding_function".into(),
+                Value::String(rounding_function_str),
+            );
+        }
+        if let Some(rounding_precision) = args.rounding_precision {
+            body.insert(
+                "rounding_precision".into(),
+                Value::Number(rounding_precision.into()),
+            );
+        }
+        if let Some(expression) = args.expression {
+            body.insert("expression".into(), Value::String(expression));
+        }
+        if let Some(field_name) = args.field_name {
+            body.insert("field_name".into(), Value::String(field_name));
+        }
+        if let Some(weighted_interval_str) = args.weighted_interval {
+            if weighted_interval_str
+                .parse::<BillableMetricWeightedInterval>()
+                .is_err()
+            {
+                return Ok(error_result(format!(
+                    "Invalid weighted_interval: {weighted_interval_str}. Valid values are: seconds"
+                )));
+            }
+            body.insert(
+                "weighted_interval".into(),
+                Value::String(weighted_interval_str),
+            );
+        }
+        if let Some(filters_input) = args.filters {
+            let filters_json: Vec<Value> = filters_input
+                .into_iter()
+                .map(|f| {
+                    serde_json::json!({
+                        "key": f.key,
+                        "values": f.values,
+                    })
+                })
+                .collect();
+            body.insert("filters".into(), Value::Array(filters_json));
+        }
+
+        let payload = serde_json::json!({ "billable_metric": Value::Object(body) });
+
+        let encoded_code = urlencoding::encode(&args.code);
+        let url = format!("{}/billable_metrics/{}", config.base_url, encoded_code);
+
+        match self
+            .http_client
+            .put(&url)
+            .bearer_auth(&config.api_key)
+            .json(&payload)
+            .send()
+            .await
+        {
+            Ok(response) if response.status().is_success() => {
+                match response.json::<Value>().await {
+                    Ok(json) => Ok(success_result(&json)),
+                    Err(e) => {
+                        let error_message =
+                            format!("Failed to parse update billable metric response: {e}");
+                        tracing::error!(
+                            code = %args.code,
+                            error = %e,
+                            "{error_message}"
+                        );
+                        Ok(error_result(error_message))
+                    }
+                }
+            }
+            Ok(response) => {
+                let status = response.status();
+                let body = response
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| "Unknown error".to_string());
+                let error_message =
+                    format!("Failed to update billable metric (HTTP {status}): {body}");
+                tracing::error!(
+                    code = %args.code,
+                    "{error_message}"
+                );
+                Ok(error_result(error_message))
+            }
+            Err(e) => {
+                let error_message = format!("Failed to update billable metric: {e}");
+                tracing::error!(
+                    code = %args.code,
+                    error = %e,
+                    "{error_message}"
+                );
                 Ok(error_result(error_message))
             }
         }

--- a/mcp/src/tools/billable_metric.rs
+++ b/mcp/src/tools/billable_metric.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use rmcp::{RoleServer, handler::server::tool::Parameters, model::*, service::RequestContext};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 use lago_types::{
     filters::billable_metric::BillableMetricFilter,
@@ -11,11 +10,11 @@ use lago_types::{
     },
     requests::billable_metric::{
         CreateBillableMetricInput, CreateBillableMetricRequest, GetBillableMetricRequest,
-        ListBillableMetricsRequest,
+        ListBillableMetricsRequest, UpdateBillableMetricInput, UpdateBillableMetricRequest,
     },
 };
 
-use crate::tools::{create_lago_client, error_result, get_lago_api_config, success_result};
+use crate::tools::{create_lago_client, error_result, success_result};
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct ListBillableMetricsArgs {
@@ -78,15 +77,11 @@ pub struct BillableMetricFilterInput {
 }
 
 #[derive(Clone)]
-pub struct BillableMetricService {
-    http_client: reqwest::Client,
-}
+pub struct BillableMetricService;
 
 impl BillableMetricService {
     pub fn new() -> Self {
-        Self {
-            http_client: reqwest::Client::new(),
-        }
+        Self
     }
 
     #[allow(clippy::collapsible_if)]
@@ -265,127 +260,78 @@ impl BillableMetricService {
         Parameters(args): Parameters<UpdateBillableMetricArgs>,
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
-        let config = match get_lago_api_config(&context).await {
-            Ok(config) => config,
+        let client = match create_lago_client(&context).await {
+            Ok(client) => client,
             Err(error_result) => return Ok(error_result),
         };
 
-        let mut body = serde_json::Map::new();
+        let mut input = UpdateBillableMetricInput::new();
 
         if let Some(name) = args.name {
-            body.insert("name".into(), Value::String(name));
+            input = input.with_name(name);
         }
         if let Some(new_code) = args.new_code {
-            body.insert("code".into(), Value::String(new_code));
+            input = input.with_code(new_code);
         }
         if let Some(description) = args.description {
-            body.insert("description".into(), Value::String(description));
+            input = input.with_description(description);
         }
         if let Some(recurring) = args.recurring {
-            body.insert("recurring".into(), Value::Bool(recurring));
+            input = input.with_recurring(recurring);
         }
         if let Some(rounding_function_str) = args.rounding_function {
-            if rounding_function_str
-                .parse::<BillableMetricRoundingFunction>()
-                .is_err()
-            {
-                return Ok(error_result(format!(
-                    "Invalid rounding_function: {rounding_function_str}. Valid values are: round, ceil, floor"
-                )));
-            }
-            body.insert(
-                "rounding_function".into(),
-                Value::String(rounding_function_str),
-            );
-        }
-        if let Some(rounding_precision) = args.rounding_precision {
-            body.insert(
-                "rounding_precision".into(),
-                Value::Number(rounding_precision.into()),
-            );
-        }
-        if let Some(expression) = args.expression {
-            body.insert("expression".into(), Value::String(expression));
-        }
-        if let Some(field_name) = args.field_name {
-            body.insert("field_name".into(), Value::String(field_name));
-        }
-        if let Some(weighted_interval_str) = args.weighted_interval {
-            if weighted_interval_str
-                .parse::<BillableMetricWeightedInterval>()
-                .is_err()
-            {
-                return Ok(error_result(format!(
-                    "Invalid weighted_interval: {weighted_interval_str}. Valid values are: seconds"
-                )));
-            }
-            body.insert(
-                "weighted_interval".into(),
-                Value::String(weighted_interval_str),
-            );
-        }
-        if let Some(filters_input) = args.filters {
-            let filters_json: Vec<Value> = filters_input
-                .into_iter()
-                .map(|f| {
-                    serde_json::json!({
-                        "key": f.key,
-                        "values": f.values,
-                    })
-                })
-                .collect();
-            body.insert("filters".into(), Value::Array(filters_json));
-        }
-
-        let payload = serde_json::json!({ "billable_metric": Value::Object(body) });
-
-        let encoded_code = urlencoding::encode(&args.code);
-        let url = format!("{}/billable_metrics/{}", config.base_url, encoded_code);
-
-        match self
-            .http_client
-            .put(&url)
-            .bearer_auth(&config.api_key)
-            .json(&payload)
-            .send()
-            .await
-        {
-            Ok(response) if response.status().is_success() => {
-                match response.json::<Value>().await {
-                    Ok(json) => Ok(success_result(&json)),
-                    Err(e) => {
-                        let error_message =
-                            format!("Failed to parse update billable metric response: {e}");
-                        tracing::error!(
-                            code = %args.code,
-                            error = %e,
-                            "{error_message}"
-                        );
-                        Ok(error_result(error_message))
-                    }
+            match rounding_function_str.parse::<BillableMetricRoundingFunction>() {
+                Ok(rounding_function) => {
+                    input = input.with_rounding_function(rounding_function);
+                }
+                Err(_) => {
+                    return Ok(error_result(format!(
+                        "Invalid rounding_function: {rounding_function_str}. Valid values are: round, ceil, floor"
+                    )));
                 }
             }
+        }
+        if let Some(rounding_precision) = args.rounding_precision {
+            input = input.with_rounding_precision(rounding_precision);
+        }
+        if let Some(expression) = args.expression {
+            input = input.with_expression(expression);
+        }
+        if let Some(field_name) = args.field_name {
+            input = input.with_field_name(field_name);
+        }
+        if let Some(weighted_interval_str) = args.weighted_interval {
+            match weighted_interval_str.parse::<BillableMetricWeightedInterval>() {
+                Ok(weighted_interval) => {
+                    input = input.with_weighted_interval(weighted_interval);
+                }
+                Err(_) => {
+                    return Ok(error_result(format!(
+                        "Invalid weighted_interval: {weighted_interval_str}. Valid values are: seconds"
+                    )));
+                }
+            }
+        }
+        if let Some(filters_input) = args.filters {
+            let filters: Vec<BillableMetricFilterModel> = filters_input
+                .into_iter()
+                .map(|f| BillableMetricFilterModel::new(f.key, f.values))
+                .collect();
+            input = input.with_filters(filters);
+        }
+
+        let request = UpdateBillableMetricRequest::new(args.code, input);
+
+        match client.update_billable_metric(request).await {
             Ok(response) => {
-                let status = response.status();
-                let body = response
-                    .text()
-                    .await
-                    .unwrap_or_else(|_| "Unknown error".to_string());
-                let error_message =
-                    format!("Failed to update billable metric (HTTP {status}): {body}");
-                tracing::error!(
-                    code = %args.code,
-                    "{error_message}"
-                );
-                Ok(error_result(error_message))
+                let result = serde_json::json!({
+                    "billable_metric": response.billable_metric,
+                });
+                Ok(success_result(&result))
             }
             Err(e) => {
                 let error_message = format!("Failed to update billable metric: {e}");
-                tracing::error!(
-                    code = %args.code,
-                    error = %e,
-                    "{error_message}"
-                );
+                tracing::error!("{error_message}");
                 Ok(error_result(error_message))
             }
         }

--- a/mcp/src/tools/coupon.rs
+++ b/mcp/src/tools/coupon.rs
@@ -332,8 +332,7 @@ impl CouponService {
                 }
                 _ => {
                     return Ok(error_result(format!(
-                        "Invalid coupon_type: {}. Must be 'fixed_amount' or 'percentage'",
-                        coupon_type
+                        "Invalid coupon_type: {coupon_type}. Must be 'fixed_amount' or 'percentage'"
                     )));
                 }
             }
@@ -344,8 +343,7 @@ impl CouponService {
                 input = input.with_frequency(frequency);
             } else {
                 return Ok(error_result(format!(
-                    "Invalid frequency: {}. Must be 'once', 'recurring', or 'forever'",
-                    frequency_str
+                    "Invalid frequency: {frequency_str}. Must be 'once', 'recurring', or 'forever'"
                 )));
             }
         }
@@ -371,8 +369,7 @@ impl CouponService {
                 input = input.with_expiration(expiration);
             } else {
                 return Ok(error_result(format!(
-                    "Invalid expiration: {}. Must be 'no_expiration' or 'time_limit'",
-                    expiration_str
+                    "Invalid expiration: {expiration_str}. Must be 'no_expiration' or 'time_limit'"
                 )));
             }
         }

--- a/mcp/src/tools/payment.rs
+++ b/mcp/src/tools/payment.rs
@@ -94,8 +94,7 @@ impl PaymentService {
                 }
                 Err(_) => {
                     return Ok(error_result(format!(
-                        "Invalid invoice_id format: {}. Must be a valid UUID.",
-                        invoice_id_str
+                        "Invalid invoice_id format: {invoice_id_str}. Must be a valid UUID."
                     )));
                 }
             }
@@ -184,8 +183,7 @@ impl PaymentService {
                 }
                 Err(_) => {
                     return Ok(error_result(format!(
-                        "Invalid invoice_id format: {}. Must be a valid UUID.",
-                        invoice_id_str
+                        "Invalid invoice_id format: {invoice_id_str}. Must be a valid UUID."
                     )));
                 }
             }

--- a/mcp/src/tools/plan.rs
+++ b/mcp/src/tools/plan.rs
@@ -423,8 +423,7 @@ impl PlanService {
                 input = input.with_interval(interval);
             } else {
                 return Ok(error_result(format!(
-                    "Invalid interval: {}. Must be one of: weekly, monthly, quarterly, semiannual, yearly",
-                    interval_str
+                    "Invalid interval: {interval_str}. Must be one of: weekly, monthly, quarterly, semiannual, yearly"
                 )));
             }
         }


### PR DESCRIPTION
## Summary

- Migrate `update_billable_metric` from a hand-rolled `reqwest::put(...)` + manual `serde_json::Map` body to the typed `lago-client` API (`UpdateBillableMetricInput` / `UpdateBillableMetricRequest` / `client.update_billable_metric(...)`), matching the shape used by `update_plan`, `update_coupon`, and `update_subscription`.
- Bump `lago-client` to `0.1.23` and `lago-types` to `0.1.21` to pick up the new update types and client method.
- Bump `rustls-webpki` in `Cargo.lock` from `0.103.10` → `0.103.12` to resolve RUSTSEC-2026-0098 / RUSTSEC-2026-0099 (both flagged by `cargo audit`).

Net result: `-104 / +50` lines in `mcp/src/tools/billable_metric.rs`; no more raw HTTP call in the service, `http_client: reqwest::Client` field removed, `get_lago_api_config` / `serde_json::Value` imports dropped. Public MCP tool schema (`UpdateBillableMetricArgs`) is unchanged.

Note: this branch also carries the two earlier commits from the original (closed) #44 — `feat(billable_metric): Add update_billable_metric tool` and `chore: Fix clippy uninlined_format_args warnings` — so the PR as a whole adds the tool *and* migrates it to the Rust client.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` / `cargo test --all-features` (0 unit tests exist in the crate)
- [x] `cargo check --release`
- [x] `cargo audit` — exit 0 after the rustls-webpki bump. Two warnings remain (`paste` unmaintained, `rand` unsound) — both transitive via `rmcp 0.6.0`, pre-existing on `main`.
- [ ] End-to-end: start the server, call `update_billable_metric` against a sandbox with `{ code, description, recurring }`, verify the returned `billable_metric` reflects the change.
- [ ] Negative path: call with `rounding_function: "not_a_value"` and verify the typed error is returned without hitting the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)