### PR TITLE
Patch rand / openssl / rustls-webpki advisories

### DIFF
--- a/mcp/Cargo.lock
+++ b/mcp/Cargo.lock
@@ -1122,15 +1122,14 @@ checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "openssl"
-version = "0.10.73"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -1154,9 +1153,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.109"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
@@ -1316,9 +1315,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1542,9 +1541,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
rustls-webpki 0.103.10 -> 0.103.13:
- RUSTSEC-2026-0098  Name constraints for URI names incorrectly accepted
- RUSTSEC-2026-0099  Name constraints accepted for wildcard certs
- RUSTSEC-2026-0104  Reachable panic in CRL parsing (GHSA-82j2-j2ch-gfr8)

rand 0.9.2 -> 0.9.4:
- RUSTSEC-2026-0097  Unsound with custom logger using rand::rng() (GHSA-cq8v-f236-94qc)

openssl 0.10.73 -> 0.10.79:
- CVE-2026-41678  AES key wrap inverted bounds check (out-of-bounds write)
- CVE-2026-41681  digest_final() out-of-bounds write (CVSS 8.1)
- (plus 3 more CVEs fixed in rust-openssl 0.10.78)

All five vulnerabilities are in transitive dependencies pulled in by rmcp, reqwest, and quinn. None of the vulnerable code paths are reachable in this codebase (no custom logger touches rand::rng, no AES key unwrap, no CRL revocation checking enabled, no certs parsed with name-constraint URI/wildcard issues since we use default rustls config).

Note: cargo audit still warns 'paste 1.0.15 unmaintained'. Pulled in via rmcp 0.6.0; no fix available upstream and not a vulnerability. Will resolve when rmcp drops or replaces paste.

Verified clean via cargo audit on the three target advisories.