### PR TITLE
feat(mcp): add list_fees and get_fee tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ For self-hosted Lago, replace `LAGO_API_URL` with your instance URL.
 - **`retry_invoice_payment`**: Retry payment collection for an invoice
 - **`void_invoice`**: Void a finalized invoice to prevent further modifications or payments
 
+### Fees
+- **`list_fees`**: List fees with filtering by fee type, billable metric code, customer, subscription, currency, payment status, and date range. Useful for custom revenue reporting and MRR calculations that need to include selected usage charges (e.g., seats, storage) alongside subscription fees.
+- **`get_fee`**: Retrieve a specific fee by its Lago ID
+
 ### Customers
 - **`get_customer`**: Retrieve a customer by external ID
 - **`list_customers`**: List customers with optional filtering

--- a/mcp/Cargo.lock
+++ b/mcp/Cargo.lock
@@ -915,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "lago-client"
-version = "0.1.23"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1666f882dfdb387c20f8216902cff13138dbafb9f229ec3c5d9f6982bdd0fceb"
+checksum = "c64cf88fc6bc4bf34f62089d10dccb82c5577601de861b818bf9346be4166cb6"
 dependencies = [
  "anyhow",
  "lago-types",
@@ -957,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "lago-types"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95cbc412f63d7cf30c04cc81bc4fe4ee1bf5efe3ce4adb889c23b0673f17e6a3"
+checksum = "51d484cc75281cf030334eb5b05ec21cb16e85a29f5f2046f494ae8c9e6c9482"
 dependencies = [
  "chrono",
  "reqwest",

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -23,8 +23,8 @@ async-trait = "0.1"
 schemars = { version = "1.0", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-lago-client = "0.1.23"
-lago-types = "0.1.21"
+lago-client = "0.1.25"
+lago-types = "0.1.23"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 urlencoding = "2.1"
 clap = { version = "4.5", features = ["derive"] }

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -17,6 +17,7 @@ use crate::tools::credit_note::CreditNoteService;
 use crate::tools::customer::CustomerService;
 use crate::tools::customer_usage::CustomerUsageService;
 use crate::tools::event::EventService;
+use crate::tools::fee::FeeService;
 use crate::tools::invoice::InvoiceService;
 use crate::tools::payment::PaymentService;
 use crate::tools::plan::PlanService;
@@ -36,6 +37,7 @@ pub struct LagoMcpServer {
     coupon_service: CouponService,
     credit_note_service: CreditNoteService,
     event_service: EventService,
+    fee_service: FeeService,
     payment_service: PaymentService,
     plan_service: PlanService,
     tool_router: ToolRouter<Self>,
@@ -55,6 +57,7 @@ impl LagoMcpServer {
         let coupon_service = CouponService::new();
         let credit_note_service = CreditNoteService::new();
         let event_service = EventService::new();
+        let fee_service = FeeService::new();
         let payment_service = PaymentService::new();
         let plan_service = PlanService::new();
 
@@ -70,6 +73,7 @@ impl LagoMcpServer {
             coupon_service,
             credit_note_service,
             event_service,
+            fee_service,
             payment_service,
             plan_service,
             tool_router: Self::tool_router(),
@@ -229,6 +233,32 @@ impl LagoMcpServer {
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         self.invoice_service.void_invoice(parameters, context).await
+    }
+
+    #[tool(
+        description = "List fees from Lago with optional filtering by fee type, billable metric code, customer, subscription, currency, payment status, and date range. \
+            Use this to access fee-level data for custom revenue and MRR reporting that needs more granularity than invoice totals. \
+            For MRR calculations that include selected usage charges (e.g., seats, storage) alongside subscription fees, \
+            filter by `billable_metric_code` to isolate the relevant usage fees, or by `fee_type='subscription'` for recurring base fees only. \
+            Use `created_at_from` / `created_at_to` to scope to a billing period."
+    )]
+    pub async fn list_fees(
+        &self,
+        parameters: Parameters<crate::tools::fee::ListFeesArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        self.fee_service.list_fees(parameters, context).await
+    }
+
+    #[tool(
+        description = "Get a specific fee by its Lago ID (UUID). Returns detailed fee information including amount, fee type, associated billable metric (if any), customer, subscription, and payment status."
+    )]
+    pub async fn get_fee(
+        &self,
+        parameters: Parameters<crate::tools::fee::GetFeeArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        self.fee_service.get_fee(parameters, context).await
     }
 
     #[tool(description = "Get a specific customer by their external ID")]

--- a/mcp/src/tools.rs
+++ b/mcp/src/tools.rs
@@ -7,6 +7,7 @@ pub mod credit_note;
 pub mod customer;
 pub mod customer_usage;
 pub mod event;
+pub mod fee;
 pub mod invoice;
 pub mod payment;
 pub mod plan;

--- a/mcp/src/tools/fee.rs
+++ b/mcp/src/tools/fee.rs
@@ -1,0 +1,167 @@
+use anyhow::Result;
+use rmcp::{RoleServer, handler::server::tool::Parameters, model::*, service::RequestContext};
+use serde::{Deserialize, Serialize};
+
+use lago_types::{
+    filters::fee::FeeFilters,
+    models::{FeePaymentStatus, FeeType, PaginationParams},
+    requests::fee::{GetFeeRequest, ListFeesRequest},
+};
+
+use crate::tools::{create_lago_client, error_result, success_result};
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct ListFeesArgs {
+    /// Filter by fee type. Valid values: 'charge' (usage-based fee from a billable metric),
+    /// 'add_on' (one-off fee), 'subscription' (recurring base fee from a plan),
+    /// 'credit' (credit fee), 'commitment' (minimum commitment fee).
+    /// For MRR calculations: 'subscription' fees are always recurring revenue; 'charge'
+    /// fees are usage-based and may or may not count toward MRR depending on the underlying
+    /// billable metric (e.g., 'seats' typically counts, 'api_calls' typically does not).
+    pub fee_type: Option<String>,
+    /// Filter by the billable metric code (e.g., "seats", "storage_gb"). Useful for
+    /// isolating specific usage charges that the customer counts as recurring revenue.
+    pub billable_metric_code: Option<String>,
+    /// Filter by the customer external ID.
+    pub external_customer_id: Option<String>,
+    /// Filter by the subscription external ID.
+    pub external_subscription_id: Option<String>,
+    /// Filter by ISO 4217 currency code (e.g., "USD", "EUR").
+    pub currency: Option<String>,
+    /// Filter by payment status. Valid values: 'pending', 'succeeded', 'failed', 'refunded'.
+    pub payment_status: Option<String>,
+    /// Filter by fee creation date (from). Format: YYYY-MM-DD or ISO 8601.
+    pub created_at_from: Option<String>,
+    /// Filter by fee creation date (to). Format: YYYY-MM-DD or ISO 8601.
+    pub created_at_to: Option<String>,
+    /// Page number for pagination (default: 1).
+    pub page: Option<i32>,
+    /// Number of results per page (default: 20, max: 100).
+    pub per_page: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct GetFeeArgs {
+    /// The Lago ID (UUID) of the fee to retrieve.
+    pub lago_id: String,
+}
+
+#[derive(Clone)]
+pub struct FeeService;
+
+impl FeeService {
+    pub fn new() -> Self {
+        Self
+    }
+
+    #[allow(clippy::collapsible_if)]
+    fn build_request(&self, args: &ListFeesArgs) -> ListFeesRequest {
+        let mut filters = FeeFilters::new();
+
+        if let Some(customer_id) = &args.external_customer_id {
+            filters = filters.with_customer_id(customer_id.clone());
+        }
+
+        if let Some(from) = &args.created_at_from {
+            filters = filters.with_created_at_from(from.clone());
+        }
+
+        if let Some(to) = &args.created_at_to {
+            filters = filters.with_created_at_to(to.clone());
+        }
+
+        if let Some(fee_type_str) = &args.fee_type {
+            if let Ok(fee_type) = fee_type_str.parse::<FeeType>() {
+                filters = filters.with_fee_type(fee_type);
+            }
+        }
+
+        if let Some(payment_status_str) = &args.payment_status {
+            if let Ok(payment_status) = payment_status_str.parse::<FeePaymentStatus>() {
+                filters = filters.with_payment_status(payment_status);
+            }
+        }
+
+        if let Some(code) = &args.billable_metric_code {
+            filters = filters.with_billable_metric_code(code.clone());
+        }
+
+        if let Some(sub_id) = &args.external_subscription_id {
+            filters = filters.with_external_subscription_id(sub_id.clone());
+        }
+
+        if let Some(currency) = &args.currency {
+            filters = filters.with_currency(currency.clone());
+        }
+
+        let mut pagination = PaginationParams::default();
+        if let Some(page) = args.page {
+            pagination = pagination.with_page(page);
+        }
+
+        if let Some(per_page) = args.per_page {
+            pagination = pagination.with_per_page(per_page);
+        }
+
+        ListFeesRequest::new()
+            .with_filters(filters)
+            .with_pagination(pagination)
+    }
+}
+
+impl FeeService {
+    pub async fn list_fees(
+        &self,
+        Parameters(args): Parameters<ListFeesArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let client = match create_lago_client(&context).await {
+            Ok(client) => client,
+            Err(error_result) => return Ok(error_result),
+        };
+        let request = self.build_request(&args);
+
+        match client.list_fees(Some(request)).await {
+            Ok(response) => {
+                let result = serde_json::json!({
+                    "fees": response.fees,
+                    "pagination": response.meta,
+                });
+
+                Ok(success_result(&result))
+            }
+            Err(e) => {
+                let error_message = format!("Failed to list fees: {e}");
+                tracing::error!("{error_message}");
+                Ok(error_result(error_message))
+            }
+        }
+    }
+
+    pub async fn get_fee(
+        &self,
+        Parameters(args): Parameters<GetFeeArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let client = match create_lago_client(&context).await {
+            Ok(client) => client,
+            Err(error_result) => return Ok(error_result),
+        };
+        let request = GetFeeRequest::new(args.lago_id);
+
+        match client.get_fee(request).await {
+            Ok(response) => {
+                let result = serde_json::json!({
+                    "fee": response.fee,
+                });
+
+                Ok(success_result(&result))
+            }
+            Err(e) => {
+                let error_message = format!("Failed to get fee: {e}");
+                tracing::error!("{error_message}");
+                Ok(error_result(error_message))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds two read-only MCP tools that expose Lago's `/fees` endpoint to AI agents:

- **`list_fees`** — list with rich filters (fee type, billable metric code, customer, subscription, currency, payment status, created-at date range, pagination)
- **`get_fee`** — single fee by Lago ID (UUID)

This is the third PR in a chain. Depends on:
- [getlago/lago-rust-client#44](https://github.com/getlago/lago-rust-client/pull/44) — lago-types fee modules (merged, published as `lago-types 0.1.23` via #45)
- [getlago/lago-rust-client#47](https://github.com/getlago/lago-rust-client/pull/47) — lago-client `list_fees` / `get_fee` methods (merged, published as `lago-client 0.1.25`)

## Code changes

| File | Change |
|---|---|
| `mcp/src/tools/fee.rs` (new) | `ListFeesArgs`, `GetFeeArgs`, `FeeService` with `build_request`, `list_fees`, `get_fee` handlers. Mirrors the existing `invoice.rs` pattern. |
| `mcp/src/tools.rs` | `pub mod fee;` |
| `mcp/src/server.rs` | Imports `FeeService`, adds field to `LagoMcpServer`, instantiates in `new()`, registers two `#[tool(description=...)]` methods. |
| `mcp/Cargo.toml` | Bumps `lago-client` to 0.1.25 and `lago-types` to 0.1.23. |
| `README.md` | New `### Fees` section under Available Tools. |

## Tool descriptions (what the LLM reads)

The `#[tool(description=...)]` strings shape when the model decides to call these tools:

- `list_fees` description explicitly mentions _"MRR calculations"_ and _"selected usage charges (e.g., seats, storage)"_. This is the surface that connects _"What's our MRR including seats?"_ to a `list_fees` call with `billable_metric_code=seats`.
- `get_fee` is a standard drill-down by Lago ID — used as a follow-up to a `list_fees` result.

Happy to adjust wording if there's a preferred phrasing.

## What this PR does NOT do

- **Mistral agent config sync.** The function schemas in Mistral's agent console are hand-maintained today. After this merges and the MCP server is deployed, someone needs to paste the `list_fees` and `get_fee` schemas into the Mistral agent. Tracked as operational followup.
- **Schema-level `per_page` max enforcement.** The arg description says "max: 100" but the JSON Schema doesn't enforce it. Matches the existing pattern in `invoice.rs` and every other paginated tool. Worth a separate cleanup PR.
- **Destructive-op safety scaffolding.** Both new tools are read-only, so unaffected. The pattern still needs designing for the existing mutating tools — separate effort.

## Test plan

Verified end-to-end locally against a real Lago account (4,521 fees in test data):

- [x] `cargo build` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — passes
- [x] MCP server boots on port 3000, `/health` responds
- [x] `tools/list` advertises both new tools (55 total, up from 53)
- [x] `tools/call list_fees` with `per_page=3` returned 3 real fees with valid pagination metadata
- [x] `tools/call get_fee` with a UUID from the list response returned the matching single fee
- [x] `tools/call list_fees` with `fee_type=subscription` correctly filtered server-side

## Commits

```
0a3ee19 chore(mcp): bump lago-client to 0.1.25 and lago-types to 0.1.23
7621e71 feat(mcp): add list_fees and get_fee MCP tools
```