### PR TITLE
Add MCP reporting reconciliation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ Works with Claude Desktop today.
 An MCP (Model Context Protocol) server written in Rust, distributed as a Docker image. It bridges AI agents and Lago's billing API.
 
 **Features:**
-- Full access to Lago's billing primitives as 40 MCP tools
+- Full access to Lago's billing primitives as 62 MCP tools
 - Type-safe Rust implementation
 - Multi-architecture Docker image (AMD64 & ARM64)
 - Pagination support for large datasets
-- Filter invoices, customers, payments, events with rich query parameters
+- Filter invoices, customers, payments, fees, wallets, wallet transactions, and events with rich query parameters
+- Finance-grade reconciliation helpers for customer-level revenue, wallet credit rollforwards, one-off invoice breakdowns, and event-to-fee tracing
 
 ## The Managed Agents context
 
@@ -61,6 +62,9 @@ For self-hosted Lago, replace `LAGO_API_URL` with your instance URL.
 - *"Give me the total amount of overdue invoices for March 2025"* → `list_invoices` + agent aggregation
 - *"Preview an invoice for customer X with 500 additional API-call events"* → `preview_invoice`
 - *"Retry payment on invoice INV-123"* → `retry_invoice_payment`
+- *"Show customer-level usage revenue and one-off invoices for March"* → `list_fees` + `list_invoices`
+- *"Reconcile credits in, credits out, and wallet balance by customer"* → `list_wallets` + `list_wallet_transactions`
+- *"Trace this usage event into its rated fee and invoice line"* → `list_enriched_events` + `list_fees` + `get_invoice`
 
 ## Available Tools
 
@@ -79,8 +83,16 @@ For self-hosted Lago, replace `LAGO_API_URL` with your instance URL.
 - **`void_invoice`**: Void a finalized invoice to prevent further modifications or payments
 
 ### Fees
-- **`list_fees`**: List fees with filtering by fee type, billable metric code, customer, subscription, currency, payment status, and date range. Useful for custom revenue reporting and MRR calculations that need to include selected usage charges (e.g., seats, storage) alongside subscription fees.
+- **`list_fees`**: List fees with filtering by fee type, billable metric code, customer, subscription, currency, event transaction ID, payment status, and created/succeeded/failed/refunded date ranges. Useful for custom revenue reporting, MRR calculations that need selected usage charges (e.g., seats, storage), and tracing pay-in-advance events into rated fee lines.
 - **`get_fee`**: Retrieve a specific fee by its Lago ID
+
+### Wallets
+- **`list_wallets`**: List wallets by customer, currency, or billing entity for wallet balances and credit rollforwards
+- **`get_wallet`**: Retrieve a specific wallet by Lago ID
+- **`list_wallet_transactions`**: List wallet credit movements by wallet, direction, processing status, and business status
+- **`get_wallet_transaction`**: Retrieve a specific wallet transaction by Lago ID
+- **`list_wallet_transaction_consumptions`**: For a traceable inbound wallet transaction, list the outbound invoice transactions that consumed it
+- **`list_wallet_transaction_fundings`**: For a traceable outbound wallet transaction, list the inbound credits that funded it
 
 ### Customers
 - **`get_customer`**: Retrieve a customer by external ID
@@ -107,6 +119,7 @@ For self-hosted Lago, replace `LAGO_API_URL` with your instance URL.
 - **`get_event`**: Retrieve a usage event by transaction ID
 - **`create_event`**: Send a usage event to Lago
 - **`list_events`**: List usage events with optional filtering by subscription, code, and timestamp range
+- **`list_enriched_events`**: List enriched events with post-enrichment values, decimal values, precise amounts, and properties for event-to-invoice reconciliation
 
 ### Credit Notes
 - **`get_credit_note`**: Retrieve a specific credit note by Lago ID

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -20,7 +20,10 @@ The Model Context Protocol (MCP) is a standardized way for AI assistants to inte
 - **API Log Management**: Query API logs to monitor API requests and responses
 - **Applied Coupon Management**: Apply coupons to customers and list applied coupons
 - **Event Management**: Send and retrieve usage events for billing
-- **Filtering Support**: Filter invoices, customers, subscriptions, plans, billable metrics, logs, and applied coupons by various criteria
+- **Enriched Event Reconciliation**: Retrieve enriched events with calculated values used in fee and invoice generation
+- **Fee Reporting**: Filter fee-level revenue by customer, subscription, billable metric, event transaction, payment status, and lifecycle dates
+- **Wallet Reconciliation**: List wallets and wallet transactions to explain credits in, credits out, voids, invoice consumption, and balance rollforwards
+- **Filtering Support**: Filter invoices, customers, subscriptions, plans, billable metrics, logs, fees, wallets, wallet transactions, and applied coupons by various criteria
 - **Pagination**: Handle large result sets with built-in pagination
 - **Type Safety**: Fully typed requests and responses using Rust
 - **Multi-tenant Support**: Per-request client creation for handling multiple tenants
@@ -536,9 +539,35 @@ List all usage events from Lago with optional filtering by subscription, billabl
 }
 ```
 
+#### 24. `list_enriched_events`
+List enriched usage events with the post-enrichment values used for reconciliation and rating. This is useful when you need to show raw event -> enriched event -> usage -> fee -> invoice math.
+
+**Parameters:** same as `list_events`.
+
+**Note:** This endpoint requires the organization to use Lago's ClickHouse events store.
+
+### Fee and Wallet Reporting Tools
+
+#### `list_fees`
+List fee-level revenue with optional filtering by fee type, billable metric code, customer, subscription, currency, event transaction ID, payment status, and created/succeeded/failed/refunded date ranges.
+
+Use this for customer-level revenue exports, MRR views that include selected usage charges, one-off/add-on breakdowns, and event-to-fee tracing.
+
+#### `list_wallets`
+List wallets by customer, currency, billing entity, and pagination. Use this to get wallet IDs, balances, consumed credits, and current credit balances before a rollforward.
+
+#### `list_wallet_transactions`
+List wallet credit movements for a wallet. Use `transaction_type='inbound'` for credits in and `transaction_type='outbound'` for credits consumed. Use `transaction_status` to separate purchased, granted/free, voided, and invoiced movements.
+
+#### `list_wallet_transaction_consumptions`
+For a traceable inbound wallet transaction, list the outbound invoice transactions that consumed it.
+
+#### `list_wallet_transaction_fundings`
+For a traceable outbound wallet transaction, list the inbound credits that funded it.
+
 ### Applied Coupon Tools
 
-#### 24. `list_applied_coupons`
+#### 25. `list_applied_coupons`
 List applied coupons with optional filtering and pagination.
 
 **Parameters:**
@@ -1369,9 +1398,11 @@ mcp/
 │   │   ├── customer.rs        # Customer-related tools
 │   │   ├── customer_usage.rs  # Customer usage-related tools
 │   │   ├── event.rs           # Event-related tools
+│   │   ├── fee.rs             # Fee reporting tools
 │   │   ├── invoice.rs         # Invoice-related tools
 │   │   ├── plan.rs            # Plan-related tools
-│   │   └── subscription.rs    # Subscription-related tools
+│   │   ├── subscription.rs    # Subscription-related tools
+│   │   └── wallet.rs          # Wallet reconciliation tools
 │   └── tools.rs         # Shared utilities and client creation
 ├── Cargo.toml           # Rust dependencies
 └── Dockerfile           # Docker configuration

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -22,6 +22,7 @@ use crate::tools::invoice::InvoiceService;
 use crate::tools::payment::PaymentService;
 use crate::tools::plan::PlanService;
 use crate::tools::subscription::SubscriptionService;
+use crate::tools::wallet::WalletService;
 
 #[derive(Clone)]
 #[allow(dead_code)]
@@ -40,6 +41,7 @@ pub struct LagoMcpServer {
     fee_service: FeeService,
     payment_service: PaymentService,
     plan_service: PlanService,
+    wallet_service: WalletService,
     tool_router: ToolRouter<Self>,
 }
 
@@ -60,6 +62,7 @@ impl LagoMcpServer {
         let fee_service = FeeService::new();
         let payment_service = PaymentService::new();
         let plan_service = PlanService::new();
+        let wallet_service = WalletService::new();
 
         Self {
             invoice_service,
@@ -76,6 +79,7 @@ impl LagoMcpServer {
             fee_service,
             payment_service,
             plan_service,
+            wallet_service,
             tool_router: Self::tool_router(),
         }
     }
@@ -236,11 +240,11 @@ impl LagoMcpServer {
     }
 
     #[tool(
-        description = "List fees from Lago with optional filtering by fee type, billable metric code, customer, subscription, currency, payment status, and date range. \
+        description = "List fees from Lago with optional filtering by fee type, billable metric code, customer, subscription, currency, payment status, event transaction ID, and date range. \
             Use this to access fee-level data for custom revenue and MRR reporting that needs more granularity than invoice totals. \
             For MRR calculations that include selected usage charges (e.g., seats, storage) alongside subscription fees, \
             filter by `billable_metric_code` to isolate the relevant usage fees, or by `fee_type='subscription'` for recurring base fees only. \
-            Use `created_at_from` / `created_at_to` to scope to a billing period."
+            Use `event_transaction_id` to trace pay-in-advance events to rated fees, and `created_at_*`, `succeeded_at_*`, `failed_at_*`, or `refunded_at_*` to scope to a billing period."
     )]
     pub async fn list_fees(
         &self,
@@ -259,6 +263,80 @@ impl LagoMcpServer {
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         self.fee_service.get_fee(parameters, context).await
+    }
+
+    #[tool(
+        description = "List wallets from Lago with optional filtering by customer, currency, and billing entity. Use this for finance reconciliation, wallet balance rollforwards, and finding the Lago wallet IDs needed to inspect credit inflows and outflows."
+    )]
+    pub async fn list_wallets(
+        &self,
+        parameters: Parameters<crate::tools::wallet::ListWalletsArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        self.wallet_service.list_wallets(parameters, context).await
+    }
+
+    #[tool(
+        description = "Get a specific wallet by its Lago ID (UUID). Returns balances, consumed credits, currency, status, limitations, recurring rules, and related customer information."
+    )]
+    pub async fn get_wallet(
+        &self,
+        parameters: Parameters<crate::tools::wallet::GetWalletArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        self.wallet_service.get_wallet(parameters, context).await
+    }
+
+    #[tool(
+        description = "List wallet transactions for a wallet. Use transaction_type='inbound' for credits in and transaction_type='outbound' for credits consumed; combine with transaction_status to separate purchased, granted, voided, and invoiced credit movements."
+    )]
+    pub async fn list_wallet_transactions(
+        &self,
+        parameters: Parameters<crate::tools::wallet::ListWalletTransactionsArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        self.wallet_service
+            .list_wallet_transactions(parameters, context)
+            .await
+    }
+
+    #[tool(
+        description = "Get a specific wallet transaction by its Lago ID (UUID). Useful for inspecting the invoice, credit note, voided invoice, amount, credit amount, remaining amount, and metadata behind a credit movement."
+    )]
+    pub async fn get_wallet_transaction(
+        &self,
+        parameters: Parameters<crate::tools::wallet::GetWalletTransactionArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        self.wallet_service
+            .get_wallet_transaction(parameters, context)
+            .await
+    }
+
+    #[tool(
+        description = "For a traceable inbound wallet transaction, list the outbound invoice transactions that consumed it. Use this to explain which invoices used a specific top-up or grant."
+    )]
+    pub async fn list_wallet_transaction_consumptions(
+        &self,
+        parameters: Parameters<crate::tools::wallet::ListWalletTransactionLinksArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        self.wallet_service
+            .list_wallet_transaction_consumptions(parameters, context)
+            .await
+    }
+
+    #[tool(
+        description = "For a traceable outbound wallet transaction, list the inbound credits that funded it. Use this to explain which top-ups or grants paid for a specific invoice credit application."
+    )]
+    pub async fn list_wallet_transaction_fundings(
+        &self,
+        parameters: Parameters<crate::tools::wallet::ListWalletTransactionLinksArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        self.wallet_service
+            .list_wallet_transaction_fundings(parameters, context)
+            .await
     }
 
     #[tool(description = "Get a specific customer by their external ID")]
@@ -582,6 +660,19 @@ impl LagoMcpServer {
     }
 
     #[tool(
+        description = "List enriched usage events from Lago with optional filtering by subscription, billable metric code, and timestamp range. Use this for reconciliation when you need the post-enrichment value, decimal value, precise amount, and properties that fed usage and fee calculation. Requires the organization to use Lago's ClickHouse events store."
+    )]
+    pub async fn list_enriched_events(
+        &self,
+        parameters: Parameters<crate::tools::event::ListEventsArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        self.event_service
+            .list_enriched_events(parameters, context)
+            .await
+    }
+
+    #[tool(
         description = "List credit notes from Lago with optional filtering by customer, dates, reason, status, and amount range"
     )]
     pub async fn list_credit_notes(
@@ -736,7 +827,7 @@ impl ServerHandler for LagoMcpServer {
     fn get_info(&self) -> ServerInfo {
         ServerInfo {
             instructions: Some(
-                "Lago MCP server for managing invoices, customers, customer usage, subscriptions, plans, billable metrics, coupons, applied coupons, credit notes, payments, activity logs, API logs, events, and other Lago resources. Use the available tools to interact with the Lago API.".into()
+                "Lago MCP server for managing invoices, customers, customer usage, subscriptions, plans, billable metrics, coupons, applied coupons, credit notes, payments, activity logs, API logs, events, wallets, fees, and other Lago resources. Use the available tools to interact with the Lago API and build billing reconciliation reports.".into()
             ),
             capabilities: ServerCapabilities::builder()
                 .enable_tools()

--- a/mcp/src/tools.rs
+++ b/mcp/src/tools.rs
@@ -12,6 +12,7 @@ pub mod invoice;
 pub mod payment;
 pub mod plan;
 pub mod subscription;
+pub mod wallet;
 
 use lago_client::{
     Config, Credentials, EnvironmentRegionProvider, LagoClient, Region, RegionProvider,

--- a/mcp/src/tools/event.rs
+++ b/mcp/src/tools/event.rs
@@ -263,4 +263,86 @@ impl EventService {
             }
         }
     }
+
+    pub async fn list_enriched_events(
+        &self,
+        Parameters(args): Parameters<ListEventsArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let config = match get_lago_api_config(&context).await {
+            Ok(config) => config,
+            Err(error_result) => return Ok(error_result),
+        };
+
+        let params = build_event_list_params(args);
+        let url = format!("{}/events_enriched", config.base_url);
+
+        match self
+            .http_client
+            .get(&url)
+            .bearer_auth(&config.api_key)
+            .query(&params)
+            .send()
+            .await
+        {
+            Ok(response) if response.status().is_success() => {
+                match response.json::<Value>().await {
+                    Ok(json) => Ok(success_result(&json)),
+                    Err(e) => {
+                        let error_message =
+                            format!("Failed to parse enriched events response: {e}");
+                        tracing::error!("{error_message}");
+                        Ok(error_result(error_message))
+                    }
+                }
+            }
+            Ok(response) => {
+                let status = response.status();
+                let body = response
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| "Unknown error".to_string());
+                let error_message =
+                    format!("Failed to list enriched events (HTTP {status}): {body}");
+                tracing::error!("{error_message}");
+                Ok(error_result(error_message))
+            }
+            Err(e) => {
+                let error_message = format!("Failed to list enriched events: {e}");
+                tracing::error!("{error_message}");
+                Ok(error_result(error_message))
+            }
+        }
+    }
+}
+
+fn build_event_list_params(args: ListEventsArgs) -> Vec<(&'static str, String)> {
+    let mut params: Vec<(&'static str, String)> = Vec::new();
+
+    if let Some(page) = args.page {
+        params.push(("page", page.to_string()));
+    }
+    if let Some(per_page) = args.per_page {
+        params.push(("per_page", per_page.to_string()));
+    }
+    if let Some(external_subscription_id) = args.external_subscription_id {
+        params.push(("external_subscription_id", external_subscription_id));
+    }
+    if let Some(code) = args.code {
+        params.push(("code", code));
+    }
+    if let Some(timestamp_from_started_at) = args.timestamp_from_started_at {
+        params.push((
+            "timestamp_from_started_at",
+            timestamp_from_started_at.to_string(),
+        ));
+    }
+    if let Some(timestamp_from) = args.timestamp_from {
+        params.push(("timestamp_from", timestamp_from));
+    }
+    if let Some(timestamp_to) = args.timestamp_to {
+        params.push(("timestamp_to", timestamp_to));
+    }
+
+    params
 }

--- a/mcp/src/tools/fee.rs
+++ b/mcp/src/tools/fee.rs
@@ -1,14 +1,12 @@
 use anyhow::Result;
+use reqwest::Client;
 use rmcp::{RoleServer, handler::server::tool::Parameters, model::*, service::RequestContext};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
-use lago_types::{
-    filters::fee::FeeFilters,
-    models::{FeePaymentStatus, FeeType, PaginationParams},
-    requests::fee::{GetFeeRequest, ListFeesRequest},
-};
+use lago_types::requests::fee::GetFeeRequest;
 
-use crate::tools::{create_lago_client, error_result, success_result};
+use crate::tools::{create_lago_client, error_result, get_lago_api_config, success_result};
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct ListFeesArgs {
@@ -28,12 +26,27 @@ pub struct ListFeesArgs {
     pub external_subscription_id: Option<String>,
     /// Filter by ISO 4217 currency code (e.g., "USD", "EUR").
     pub currency: Option<String>,
+    /// Filter pay-in-advance charge fees by the source event transaction ID. Use this to jump
+    /// from an event to the exact rated fee line when reconciling event-to-invoice math.
+    pub event_transaction_id: Option<String>,
     /// Filter by payment status. Valid values: 'pending', 'succeeded', 'failed', 'refunded'.
     pub payment_status: Option<String>,
     /// Filter by fee creation date (from). Format: YYYY-MM-DD or ISO 8601.
     pub created_at_from: Option<String>,
     /// Filter by fee creation date (to). Format: YYYY-MM-DD or ISO 8601.
     pub created_at_to: Option<String>,
+    /// Filter by succeeded date (from). Format: YYYY-MM-DD or ISO 8601.
+    pub succeeded_at_from: Option<String>,
+    /// Filter by succeeded date (to). Format: YYYY-MM-DD or ISO 8601.
+    pub succeeded_at_to: Option<String>,
+    /// Filter by failed date (from). Format: YYYY-MM-DD or ISO 8601.
+    pub failed_at_from: Option<String>,
+    /// Filter by failed date (to). Format: YYYY-MM-DD or ISO 8601.
+    pub failed_at_to: Option<String>,
+    /// Filter by refunded date (from). Format: YYYY-MM-DD or ISO 8601.
+    pub refunded_at_from: Option<String>,
+    /// Filter by refunded date (to). Format: YYYY-MM-DD or ISO 8601.
+    pub refunded_at_to: Option<String>,
     /// Page number for pagination (default: 1).
     pub page: Option<i32>,
     /// Number of results per page (default: 20, max: 100).
@@ -47,65 +60,60 @@ pub struct GetFeeArgs {
 }
 
 #[derive(Clone)]
-pub struct FeeService;
+pub struct FeeService {
+    http_client: Client,
+}
 
 impl FeeService {
     pub fn new() -> Self {
-        Self
+        Self {
+            http_client: Client::new(),
+        }
     }
 
-    #[allow(clippy::collapsible_if)]
-    fn build_request(&self, args: &ListFeesArgs) -> ListFeesRequest {
-        let mut filters = FeeFilters::new();
+    fn build_query_params(args: ListFeesArgs) -> Vec<(&'static str, String)> {
+        let mut params: Vec<(&'static str, String)> = Vec::new();
 
-        if let Some(customer_id) = &args.external_customer_id {
-            filters = filters.with_customer_id(customer_id.clone());
-        }
+        push_param(&mut params, "fee_type", args.fee_type);
+        push_param(
+            &mut params,
+            "billable_metric_code",
+            args.billable_metric_code,
+        );
+        push_param(
+            &mut params,
+            "external_customer_id",
+            args.external_customer_id,
+        );
+        push_param(
+            &mut params,
+            "external_subscription_id",
+            args.external_subscription_id,
+        );
+        push_param(&mut params, "currency", args.currency);
+        push_param(
+            &mut params,
+            "event_transaction_id",
+            args.event_transaction_id,
+        );
+        push_param(&mut params, "payment_status", args.payment_status);
+        push_param(&mut params, "created_at_from", args.created_at_from);
+        push_param(&mut params, "created_at_to", args.created_at_to);
+        push_param(&mut params, "succeeded_at_from", args.succeeded_at_from);
+        push_param(&mut params, "succeeded_at_to", args.succeeded_at_to);
+        push_param(&mut params, "failed_at_from", args.failed_at_from);
+        push_param(&mut params, "failed_at_to", args.failed_at_to);
+        push_param(&mut params, "refunded_at_from", args.refunded_at_from);
+        push_param(&mut params, "refunded_at_to", args.refunded_at_to);
 
-        if let Some(from) = &args.created_at_from {
-            filters = filters.with_created_at_from(from.clone());
-        }
-
-        if let Some(to) = &args.created_at_to {
-            filters = filters.with_created_at_to(to.clone());
-        }
-
-        if let Some(fee_type_str) = &args.fee_type {
-            if let Ok(fee_type) = fee_type_str.parse::<FeeType>() {
-                filters = filters.with_fee_type(fee_type);
-            }
-        }
-
-        if let Some(payment_status_str) = &args.payment_status {
-            if let Ok(payment_status) = payment_status_str.parse::<FeePaymentStatus>() {
-                filters = filters.with_payment_status(payment_status);
-            }
-        }
-
-        if let Some(code) = &args.billable_metric_code {
-            filters = filters.with_billable_metric_code(code.clone());
-        }
-
-        if let Some(sub_id) = &args.external_subscription_id {
-            filters = filters.with_external_subscription_id(sub_id.clone());
-        }
-
-        if let Some(currency) = &args.currency {
-            filters = filters.with_currency(currency.clone());
-        }
-
-        let mut pagination = PaginationParams::default();
         if let Some(page) = args.page {
-            pagination = pagination.with_page(page);
+            params.push(("page", page.to_string()));
         }
-
         if let Some(per_page) = args.per_page {
-            pagination = pagination.with_per_page(per_page);
+            params.push(("per_page", per_page.to_string()));
         }
 
-        ListFeesRequest::new()
-            .with_filters(filters)
-            .with_pagination(pagination)
+        params
     }
 }
 
@@ -115,20 +123,50 @@ impl FeeService {
         Parameters(args): Parameters<ListFeesArgs>,
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
-        let client = match create_lago_client(&context).await {
-            Ok(client) => client,
+        let config = match get_lago_api_config(&context).await {
+            Ok(config) => config,
             Err(error_result) => return Ok(error_result),
         };
-        let request = self.build_request(&args);
 
-        match client.list_fees(Some(request)).await {
+        let params = Self::build_query_params(args);
+        let url = format!("{}/fees", config.base_url);
+
+        match self
+            .http_client
+            .get(&url)
+            .bearer_auth(&config.api_key)
+            .query(&params)
+            .send()
+            .await
+        {
+            Ok(response) if response.status().is_success() => {
+                match response.json::<Value>().await {
+                    Ok(json) => {
+                        let result = serde_json::json!({
+                            "fees": json.get("fees").cloned().unwrap_or(Value::Array(vec![])),
+                            "pagination": json.get("meta")
+                                .or_else(|| json.get("pagination"))
+                                .cloned(),
+                        });
+
+                        Ok(success_result(&result))
+                    }
+                    Err(e) => {
+                        let error_message = format!("Failed to parse fees response: {e}");
+                        tracing::error!("{error_message}");
+                        Ok(error_result(error_message))
+                    }
+                }
+            }
             Ok(response) => {
-                let result = serde_json::json!({
-                    "fees": response.fees,
-                    "pagination": response.meta,
-                });
-
-                Ok(success_result(&result))
+                let status = response.status();
+                let body = response
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| "Unknown error".to_string());
+                let error_message = format!("Failed to list fees (HTTP {status}): {body}");
+                tracing::error!("{error_message}");
+                Ok(error_result(error_message))
             }
             Err(e) => {
                 let error_message = format!("Failed to list fees: {e}");
@@ -163,5 +201,11 @@ impl FeeService {
                 Ok(error_result(error_message))
             }
         }
+    }
+}
+
+fn push_param(params: &mut Vec<(&'static str, String)>, name: &'static str, value: Option<String>) {
+    if let Some(value) = value {
+        params.push((name, value));
     }
 }

--- a/mcp/src/tools/wallet.rs
+++ b/mcp/src/tools/wallet.rs
@@ -1,0 +1,258 @@
+use anyhow::Result;
+use reqwest::Client;
+use rmcp::{RoleServer, handler::server::tool::Parameters, model::*, service::RequestContext};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::tools::{error_result, get_lago_api_config, success_result};
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct ListWalletsArgs {
+    /// Filter wallets by customer external ID. Use this before a wallet rollforward so all
+    /// wallet IDs, balances, currencies, and current credit balances are known.
+    pub external_customer_id: Option<String>,
+    /// Filter wallets by ISO 4217 currency code (e.g., "USD", "EUR").
+    pub currency: Option<String>,
+    /// Filter wallets by billing entity codes. Each code is sent as billing_entity_codes[].
+    pub billing_entity_codes: Option<Vec<String>>,
+    /// Page number for pagination (default: 1).
+    pub page: Option<i32>,
+    /// Number of results per page (default: 20).
+    pub per_page: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct GetWalletArgs {
+    /// The Lago ID (UUID) of the wallet to retrieve.
+    pub lago_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct ListWalletTransactionsArgs {
+    /// The Lago ID (UUID) of the wallet whose transactions should be listed.
+    pub lago_wallet_id: String,
+    /// Filter by transaction direction. Valid values: 'inbound' for credits in and 'outbound'
+    /// for credits consumed by invoices or credit notes.
+    pub transaction_type: Option<String>,
+    /// Filter by processing status. Valid values: 'pending', 'settled', 'failed'.
+    pub status: Option<String>,
+    /// Filter by business status. Valid values: 'purchased', 'granted', 'voided', 'invoiced'.
+    /// Use this to separate purchased credits, granted/free credits, voided credits, and
+    /// credits applied to invoices.
+    pub transaction_status: Option<String>,
+    /// Page number for pagination (default: 1).
+    pub page: Option<i32>,
+    /// Number of results per page (default: 20).
+    pub per_page: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct GetWalletTransactionArgs {
+    /// The Lago ID (UUID) of the wallet transaction to retrieve.
+    pub lago_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct ListWalletTransactionLinksArgs {
+    /// The Lago ID (UUID) of the wallet transaction. For consumptions, pass an inbound
+    /// transaction to see which outbound invoice transactions consumed it. For fundings,
+    /// pass an outbound transaction to see which inbound credits funded it.
+    pub lago_wallet_transaction_id: String,
+    /// Page number for pagination (default: 1).
+    pub page: Option<i32>,
+    /// Number of results per page (default: 20).
+    pub per_page: Option<i32>,
+}
+
+#[derive(Clone)]
+pub struct WalletService {
+    http_client: Client,
+}
+
+impl WalletService {
+    pub fn new() -> Self {
+        Self {
+            http_client: Client::new(),
+        }
+    }
+
+    async fn get_json(
+        &self,
+        context: &RequestContext<RoleServer>,
+        path: &str,
+        params: Vec<(&str, String)>,
+        failure_context: &str,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let config = match get_lago_api_config(context).await {
+            Ok(config) => config,
+            Err(error_result) => return Ok(error_result),
+        };
+
+        let url = format!("{}{}", config.base_url, path);
+
+        match self
+            .http_client
+            .get(&url)
+            .bearer_auth(&config.api_key)
+            .query(&params)
+            .send()
+            .await
+        {
+            Ok(response) if response.status().is_success() => {
+                match response.json::<Value>().await {
+                    Ok(json) => Ok(success_result(&json)),
+                    Err(e) => {
+                        let error_message =
+                            format!("Failed to parse {failure_context} response: {e}");
+                        tracing::error!("{error_message}");
+                        Ok(error_result(error_message))
+                    }
+                }
+            }
+            Ok(response) => {
+                let status = response.status();
+                let body = response
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| "Unknown error".to_string());
+                let error_message = format!("Failed to {failure_context} (HTTP {status}): {body}");
+                tracing::error!("{error_message}");
+                Ok(error_result(error_message))
+            }
+            Err(e) => {
+                let error_message = format!("Failed to {failure_context}: {e}");
+                tracing::error!("{error_message}");
+                Ok(error_result(error_message))
+            }
+        }
+    }
+
+    pub async fn list_wallets(
+        &self,
+        Parameters(args): Parameters<ListWalletsArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let mut params: Vec<(&str, String)> = Vec::new();
+
+        if let Some(external_customer_id) = args.external_customer_id {
+            params.push(("external_customer_id", external_customer_id));
+        }
+        if let Some(currency) = args.currency {
+            params.push(("currency", currency));
+        }
+        if let Some(page) = args.page {
+            params.push(("page", page.to_string()));
+        }
+        if let Some(per_page) = args.per_page {
+            params.push(("per_page", per_page.to_string()));
+        }
+        if let Some(billing_entity_codes) = args.billing_entity_codes {
+            params.extend(
+                billing_entity_codes
+                    .into_iter()
+                    .map(|code| ("billing_entity_codes[]", code)),
+            );
+        }
+
+        self.get_json(&context, "/wallets", params, "list wallets")
+            .await
+    }
+
+    pub async fn get_wallet(
+        &self,
+        Parameters(args): Parameters<GetWalletArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let encoded_id = urlencoding::encode(&args.lago_id);
+        let path = format!("/wallets/{encoded_id}");
+
+        self.get_json(&context, &path, Vec::new(), "get wallet")
+            .await
+    }
+
+    pub async fn list_wallet_transactions(
+        &self,
+        Parameters(args): Parameters<ListWalletTransactionsArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let mut params: Vec<(&str, String)> = Vec::new();
+
+        if let Some(transaction_type) = args.transaction_type {
+            params.push(("transaction_type", transaction_type));
+        }
+        if let Some(status) = args.status {
+            params.push(("status", status));
+        }
+        if let Some(transaction_status) = args.transaction_status {
+            params.push(("transaction_status", transaction_status));
+        }
+        if let Some(page) = args.page {
+            params.push(("page", page.to_string()));
+        }
+        if let Some(per_page) = args.per_page {
+            params.push(("per_page", per_page.to_string()));
+        }
+
+        let encoded_id = urlencoding::encode(&args.lago_wallet_id);
+        let path = format!("/wallets/{encoded_id}/wallet_transactions");
+
+        self.get_json(&context, &path, params, "list wallet transactions")
+            .await
+    }
+
+    pub async fn get_wallet_transaction(
+        &self,
+        Parameters(args): Parameters<GetWalletTransactionArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let encoded_id = urlencoding::encode(&args.lago_id);
+        let path = format!("/wallet_transactions/{encoded_id}");
+
+        self.get_json(&context, &path, Vec::new(), "get wallet transaction")
+            .await
+    }
+
+    pub async fn list_wallet_transaction_consumptions(
+        &self,
+        Parameters(args): Parameters<ListWalletTransactionLinksArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let params = pagination_params(args.page, args.per_page);
+        let encoded_id = urlencoding::encode(&args.lago_wallet_transaction_id);
+        let path = format!("/wallet_transactions/{encoded_id}/consumptions");
+
+        self.get_json(
+            &context,
+            &path,
+            params,
+            "list wallet transaction consumptions",
+        )
+        .await
+    }
+
+    pub async fn list_wallet_transaction_fundings(
+        &self,
+        Parameters(args): Parameters<ListWalletTransactionLinksArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let params = pagination_params(args.page, args.per_page);
+        let encoded_id = urlencoding::encode(&args.lago_wallet_transaction_id);
+        let path = format!("/wallet_transactions/{encoded_id}/fundings");
+
+        self.get_json(&context, &path, params, "list wallet transaction fundings")
+            .await
+    }
+}
+
+fn pagination_params(page: Option<i32>, per_page: Option<i32>) -> Vec<(&'static str, String)> {
+    let mut params = Vec::new();
+
+    if let Some(page) = page {
+        params.push(("page", page.to_string()));
+    }
+    if let Some(per_page) = per_page {
+        params.push(("per_page", per_page.to_string()));
+    }
+
+    params
+}


### PR DESCRIPTION
## Summary

Adds read-only MCP reporting tools for customer finance and billing reconciliation workflows:
- wallet tools for balances, credit movements, and credit consumption/funding traces
- enriched event listing for event-to-invoice reconciliation
- expanded fee filters for event transaction IDs and lifecycle dates
- docs for customer revenue, wallet rollforward, MRR, and event-to-fee workflows

## Validation

- cargo fmt --all -- --check
- cargo check
- cargo clippy --all-features -- -D warnings
- cargo test --all-features
- cargo build --release --all-features