### PR TITLE
feat(mcp): add ask_lago_analytics tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ For operators deploying Managed Agents to their own customers and needing per-se
         "--name", "lago-mcp-server",
         "-e", "LAGO_API_KEY=your_lago_api_key",
         "-e", "LAGO_API_URL=https://api.getlago.com/api/v1",
+        "-e", "LAGO_AGENT_API_URL=https://agent.getlago.com",
         "getlago/lago-mcp-server:latest"
       ]
     }
@@ -54,6 +55,8 @@ For operators deploying Managed Agents to their own customers and needing per-se
 
 For self-hosted Lago, replace `LAGO_API_URL` with your instance URL.
 
+> **Analytics tool**: `ask_lago_analytics` additionally requires `LAGO_AGENT_API_URL` (the URL of the Lago analytics agent). If it's not set, the other tools work normally and only the analytics tool returns a configuration error. Note: this tool forwards your `X-LAGO-API-KEY` to the analytics agent service (a first-party Lago service that re-validates the key and applies the same per-organization row-level security as the Rails API). It is the one tool that does not route through the Lago REST API — see the PR description / `docs/` for the architecture rationale.
+
 ## Example prompts
 
 - *"Show me all pending invoices from last month"* → `list_invoices`
@@ -61,8 +64,14 @@ For self-hosted Lago, replace `LAGO_API_URL` with your instance URL.
 - *"Give me the total amount of overdue invoices for March 2025"* → `list_invoices` + agent aggregation
 - *"Preview an invoice for customer X with 500 additional API-call events"* → `preview_invoice`
 - *"Retry payment on invoice INV-123"* → `retry_invoice_payment`
+- *"What was our MRR for December 2025, broken down by plan?"* → `ask_lago_analytics`
+- *"List the top 10 customers by usage volume in Q1 2026."* → `ask_lago_analytics`
+- *"How many invoices went overdue last month?"* then *"Break that down by customer country."* → `ask_lago_analytics` (the second call reuses the returned `session_id`)
 
 ## Available Tools
+
+### Analytics
+- **`ask_lago_analytics`**: Ask a natural-language question about your billing and usage data (revenue, MRR, invoices, customers, subscriptions, usage volumes). The analytics agent generates a read-only SQL query, runs it, and returns the SQL, a plain-language explanation, and a results table. The response includes a `session_id` — pass it back on a follow-up call to refine the same result (filter, aggregate, sort) using the agent's cached rows.
 
 ### Invoices
 - **`find_invoice_by_number`**: Find an invoice by its number (e.g., "RAF-8142-202601-312") and get its Lago ID

--- a/mcp/.env.development.example
+++ b/mcp/.env.development.example
@@ -1,2 +1,7 @@
 MISTRAL_AGENT_ID="your_mistral_agent_id"
 MISTRAL_API_KEY="your_mistral_api_key"
+
+# Analytics agent (ask_lago_analytics tool) — the Python text-to-SQL service
+LAGO_AGENT_API_URL="https://agent.getlago.com"
+# request timeout for the analytics agent in seconds (default 60 if unset)
+LAGO_AGENT_TIMEOUT_SECS="60"

--- a/mcp/Cargo.lock
+++ b/mcp/Cargo.lock
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "lago-mcp-server"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mcp/Cargo.lock
+++ b/mcp/Cargo.lock
@@ -98,6 +98,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,6 +369,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,6 +616,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
@@ -953,6 +987,7 @@ dependencies = [
  "tracing-subscriber",
  "urlencoding",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]
@@ -1097,6 +1132,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -1369,6 +1414,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "regex"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2531,6 +2588,29 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lago-mcp-server"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [dependencies]

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -30,3 +30,6 @@ urlencoding = "2.1"
 clap = { version = "4.5", features = ["derive"] }
 tokio-util = "0.7"
 axum = { version = "0.8", features = ["macros"] }
+
+[dev-dependencies]
+wiremock = "0.6"

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -9,6 +9,7 @@ use rmcp::{
 use std::future::Future;
 
 use crate::tools::activity_log::ActivityLogService;
+use crate::tools::analytics::AnalyticsService;
 use crate::tools::api_log::ApiLogService;
 use crate::tools::applied_coupon::AppliedCouponService;
 use crate::tools::billable_metric::BillableMetricService;
@@ -32,6 +33,7 @@ pub struct LagoMcpServer {
     subscription_service: SubscriptionService,
     billable_metric_service: BillableMetricService,
     activity_log_service: ActivityLogService,
+    analytics_service: AnalyticsService,
     api_log_service: ApiLogService,
     applied_coupon_service: AppliedCouponService,
     coupon_service: CouponService,
@@ -52,6 +54,7 @@ impl LagoMcpServer {
         let subscription_service = SubscriptionService::new();
         let billable_metric_service = BillableMetricService::new();
         let activity_log_service = ActivityLogService::new();
+        let analytics_service = AnalyticsService::new();
         let api_log_service = ApiLogService::new();
         let applied_coupon_service = AppliedCouponService::new();
         let coupon_service = CouponService::new();
@@ -68,6 +71,7 @@ impl LagoMcpServer {
             subscription_service,
             billable_metric_service,
             activity_log_service,
+            analytics_service,
             api_log_service,
             applied_coupon_service,
             coupon_service,
@@ -259,6 +263,20 @@ impl LagoMcpServer {
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         self.fee_service.get_fee(parameters, context).await
+    }
+
+    #[tool(
+        description = "Ask the Lago analytics agent a natural-language question about your billing and usage data (revenue, MRR, invoices, customers, subscriptions, usage volumes, and more). \
+            The agent generates a read-only SQL query, runs it against your analytics database, and returns the SQL, a plain-language explanation, and a results table as Markdown. \
+            Use this for ad-hoc analytical questions that don't map to a specific billing endpoint — trends, aggregations, breakdowns, and cross-entity reporting. \
+            The response embeds a `session_id` in a JSON block; to refine the same result (filter, aggregate, sort, drill down), call this tool again with that exact `session_id` plus a follow-up question, and the agent reuses the cached rows instead of re-querying."
+    )]
+    pub async fn ask_lago_analytics(
+        &self,
+        parameters: Parameters<crate::tools::analytics::AskParams>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        self.analytics_service.ask(parameters, context).await
     }
 
     #[tool(description = "Get a specific customer by their external ID")]

--- a/mcp/src/tools.rs
+++ b/mcp/src/tools.rs
@@ -1,4 +1,5 @@
 pub mod activity_log;
+pub mod analytics;
 pub mod api_log;
 pub mod applied_coupon;
 pub mod billable_metric;

--- a/mcp/src/tools/analytics.rs
+++ b/mcp/src/tools/analytics.rs
@@ -1,0 +1,289 @@
+// APPROVED SECURITY EXCEPTION (see CLAUDE.md):
+//
+// Every other tool in this crate reaches data through `lago-client` -> Lago Rails,
+// and the `X-LAGO-API-KEY` is only ever forwarded to Rails. This tool is an
+// intentional, reviewed exception: it calls the first-party Lago analytics agent
+// (`agent.getlago.com`) directly over HTTP via `reqwest`, NOT through `lago-client`.
+//
+// Why this is still safe and org-isolated:
+//   - The agent is a first-party Lago service, not a third party. The api_key we
+//     forward is re-validated by the agent against the Lago REST API on every call,
+//     so an invalid/forged key is rejected upstream exactly as Rails would reject it.
+//   - After resolving the org from that key, the agent applies row-level security
+//     keyed off the resolved org, so a caller can only ever see their own org's rows.
+//   - The agent queries a read-only analytical Postgres replica purpose-built for
+//     text-to-SQL reporting, not arbitrary application storage. There is no write
+//     path and no cross-org data surface.
+//
+// Net effect: the same key boundary and org isolation guarantees hold; only the
+// transport (direct reqwest to a first-party analytics service) differs from the
+// rest of the crate.
+
+// the service is constructed and called from server.rs once the tool is registered
+// (next task); until then these items are unreferenced outside the test module.
+#![allow(dead_code)]
+
+use rmcp::{
+    RoleServer,
+    handler::server::tool::Parameters,
+    model::{CallToolResult, Content},
+    service::RequestContext,
+};
+use serde::{Deserialize, Serialize};
+use std::env;
+use std::time::Duration;
+
+use crate::tools::{error_result, get_lago_api_config};
+
+// default agent request timeout when LAGO_AGENT_TIMEOUT_SECS is unset/invalid
+const DEFAULT_AGENT_TIMEOUT_SECS: u64 = 60;
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct AskParams {
+    /// Natural-language question about your Lago billing/usage data. The analytics agent
+    /// turns it into SQL, runs it, and returns the SQL, an explanation, and a results table.
+    pub question: String,
+    /// Optional session_id returned by a previous ask_lago_analytics response. Pass it back
+    /// to refine the previous result (filter, aggregate, sort) using the agent's cached rows.
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct AgentAskRequest {
+    question: String,
+    // omit the field entirely on a fresh ask so the agent treats it as a new session
+    #[serde(skip_serializing_if = "Option::is_none")]
+    session_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AgentAskResponse {
+    sql_query: String,
+    explanation: String,
+    results: String,
+    session_id: String,
+    // the agent only sets this when a passed-in session_id had expired and it answered fresh
+    #[serde(default)]
+    session_expired: bool,
+}
+
+// pure renderer: no I/O, no RequestContext, so it is unit-testable in isolation.
+fn render_markdown(resp: &AgentAskResponse) -> String {
+    // surface to the caller that their follow-up session was gone and this is a fresh answer
+    let expired_note = if resp.session_expired {
+        "(previous session expired; this was answered fresh)\n\n"
+    } else {
+        ""
+    };
+
+    format!(
+        "```sql\n{sql}\n```\n\n{expired}{explanation}\n\n{results}\n\n---\n\nFollow-up: call this tool again with the `session_id` below to refine this result via the agent's cached rows.\n\n```json\n{{\"session_id\": \"{session_id}\"}}\n```\n",
+        sql = resp.sql_query,
+        expired = expired_note,
+        explanation = resp.explanation,
+        results = resp.results,
+        session_id = resp.session_id,
+    )
+}
+
+// takes the resolved api_key + agent_url as plain params (no RequestContext), so the
+// HTTP path is fully testable with a mock server. returns the parsed response or an
+// error CallToolResult ready to hand back to the caller.
+async fn call_agent(
+    client: &reqwest::Client,
+    agent_url: &str,
+    api_key: &str,
+    body: &AgentAskRequest,
+) -> Result<AgentAskResponse, CallToolResult> {
+    let ask_url = format!("{}/ask", agent_url.trim_end_matches('/'));
+
+    let response = client
+        .post(&ask_url)
+        .header("X-LAGO-API-KEY", api_key)
+        .json(body)
+        .send()
+        .await
+        .map_err(|e| {
+            // distinguish a timeout from a connection/transport failure for a clearer message
+            if e.is_timeout() {
+                error_result("Analytics agent request timed out")
+            } else {
+                error_result(format!("Analytics agent unreachable: {e}"))
+            }
+        })?;
+
+    let status = response.status();
+    if !status.is_success() {
+        // forward the upstream status + body so the caller can see the agent's own error
+        let body_text = response.text().await.unwrap_or_default();
+        return Err(error_result(format!(
+            "Analytics agent returned {status}: {body_text}"
+        )));
+    }
+
+    response
+        .json::<AgentAskResponse>()
+        .await
+        .map_err(|e| error_result(format!("Failed to parse agent response: {e}")))
+}
+
+#[derive(Clone)]
+pub struct AnalyticsService;
+
+impl AnalyticsService {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub async fn ask(
+        &self,
+        Parameters(params): Parameters<AskParams>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        // reuse the crate's dual-mode key resolution; we only need the api_key here,
+        // not its base_url (that is the Lago REST url, not the agent url).
+        let api_key = match get_lago_api_config(&context).await {
+            Ok(config) => config.api_key,
+            Err(error_result) => return Ok(error_result),
+        };
+
+        // the agent url is deployment config on the MCP server, never a request header
+        let agent_url = env::var("LAGO_AGENT_API_URL").unwrap_or_default();
+        if agent_url.is_empty() {
+            return Ok(error_result(
+                "Analytics agent not configured: set LAGO_AGENT_API_URL on the MCP server.",
+            ));
+        }
+
+        // operators can tune the timeout; fall back to a sane default on unset/garbage input
+        let timeout_secs = env::var("LAGO_AGENT_TIMEOUT_SECS")
+            .ok()
+            .and_then(|raw| raw.parse::<u64>().ok())
+            .unwrap_or(DEFAULT_AGENT_TIMEOUT_SECS);
+
+        let client = match reqwest::Client::builder()
+            .timeout(Duration::from_secs(timeout_secs))
+            .build()
+        {
+            Ok(client) => client,
+            Err(e) => return Ok(error_result(format!("Failed to build HTTP client: {e}"))),
+        };
+
+        let request_body = AgentAskRequest {
+            question: params.question,
+            session_id: params.session_id,
+        };
+
+        match call_agent(&client, &agent_url, &api_key, &request_body).await {
+            Err(error_result) => Ok(error_result),
+            // happy path returns Markdown, not serialized JSON, so build the result directly
+            Ok(resp) => Ok(CallToolResult::success(vec![Content::text(
+                render_markdown(&resp),
+            )])),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn sample_response(session_expired: bool) -> AgentAskResponse {
+        AgentAskResponse {
+            sql_query: "SELECT count(*) FROM invoices".to_string(),
+            explanation: "Counts all invoices in your org.".to_string(),
+            results: "| count |\n| --- |\n| 42 |".to_string(),
+            session_id: "sess-abc-123".to_string(),
+            session_expired,
+        }
+    }
+
+    #[test]
+    fn render_markdown_includes_sql_explanation_results_and_session_json() {
+        let resp = sample_response(false);
+        let out = render_markdown(&resp);
+
+        assert!(out.contains("SELECT count(*) FROM invoices"));
+        assert!(out.contains("Counts all invoices in your org."));
+        assert!(out.contains("| count |"));
+        assert!(out.contains("```json"));
+        assert!(out.contains("\"session_id\": \"sess-abc-123\""));
+    }
+
+    #[test]
+    fn render_markdown_prepends_expired_note_when_session_expired() {
+        let resp = sample_response(true);
+        let out = render_markdown(&resp);
+
+        assert!(out.contains("previous session expired"));
+    }
+
+    #[test]
+    fn render_markdown_omits_expired_note_when_not_expired() {
+        let resp = sample_response(false);
+        let out = render_markdown(&resp);
+
+        assert!(!out.contains("previous session expired"));
+    }
+
+    #[tokio::test]
+    async fn call_agent_returns_parsed_response_on_200() {
+        let server = MockServer::start().await;
+
+        let response_body = serde_json::json!({
+            "sql_query": "SELECT 1",
+            "explanation": "ok",
+            "results": "| 1 |",
+            "session_id": "sess-xyz",
+            "session_expired": false,
+        });
+
+        // matching on the header proves we forward the key (Finding #1 regression guard)
+        Mock::given(method("POST"))
+            .and(path("/ask"))
+            .and(header("X-LAGO-API-KEY", "test-key-42"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(response_body))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let body = AgentAskRequest {
+            question: "how many?".to_string(),
+            session_id: None,
+        };
+
+        let result = call_agent(&client, &server.uri(), "test-key-42", &body).await;
+
+        let parsed = result.expect("expected Ok response from agent");
+        assert_eq!(parsed.sql_query, "SELECT 1");
+        assert_eq!(parsed.explanation, "ok");
+        assert_eq!(parsed.results, "| 1 |");
+        assert_eq!(parsed.session_id, "sess-xyz");
+        assert!(!parsed.session_expired);
+    }
+
+    #[tokio::test]
+    async fn call_agent_returns_error_result_on_non_2xx() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/ask"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("unauthorized"))
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let body = AgentAskRequest {
+            question: "how many?".to_string(),
+            session_id: None,
+        };
+
+        let result = call_agent(&client, &server.uri(), "bad-key", &body).await;
+
+        let error = result.expect_err("expected Err(CallToolResult) on non-2xx");
+        assert_eq!(error.is_error, Some(true));
+    }
+}

--- a/mcp/src/tools/analytics.rs
+++ b/mcp/src/tools/analytics.rs
@@ -19,10 +19,6 @@
 // transport (direct reqwest to a first-party analytics service) differs from the
 // rest of the crate.
 
-// the service is constructed and called from server.rs once the tool is registered
-// (next task); until then these items are unreferenced outside the test module.
-#![allow(dead_code)]
-
 use rmcp::{
     RoleServer,
     handler::server::tool::Parameters,
@@ -285,5 +281,28 @@ mod tests {
 
         let error = result.expect_err("expected Err(CallToolResult) on non-2xx");
         assert_eq!(error.is_error, Some(true));
+    }
+
+    #[tokio::test]
+    async fn call_agent_returns_error_result_on_malformed_body() {
+        // a 200 with a body that isn't a valid AgentAskResponse must surface as an
+        // error CallToolResult, not panic or silently succeed
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/ask"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("not json at all"))
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let body = AgentAskRequest {
+            question: "q".to_string(),
+            session_id: None,
+        };
+        let result = call_agent(&client, &server.uri(), "k", &body).await;
+
+        assert!(result.is_err());
+        let ctr = result.unwrap_err();
+        assert_eq!(ctr.is_error, Some(true));
     }
 }

--- a/mcp/src/tools/analytics.rs
+++ b/mcp/src/tools/analytics.rs
@@ -123,6 +123,42 @@ async fn call_agent(
         .map_err(|e| error_result(format!("Failed to parse agent response: {e}")))
 }
 
+// We forward X-LAGO-API-KEY to the agent, so require an encrypted channel. Plaintext
+// http:// is allowed only for loopback hosts (local dev / self-hosted on the same box).
+// We deliberately do NOT pin a host allowlist: LAGO_AGENT_API_URL is operator-controlled
+// deployment config and self-hosted operators run their own analytics agent host.
+fn validate_agent_url(raw: &str) -> Result<(), String> {
+    let url = reqwest::Url::parse(raw)
+        .map_err(|e| format!("LAGO_AGENT_API_URL is not a valid URL: {e}"))?;
+
+    let host_is_loopback = matches!(
+        url.host_str(),
+        Some("localhost") | Some("127.0.0.1") | Some("::1") | Some("[::1]")
+    );
+
+    match url.scheme() {
+        "https" => Ok(()),
+        "http" if host_is_loopback => Ok(()),
+        "http" => Err(
+            "LAGO_AGENT_API_URL must use https; plaintext http is only allowed for localhost."
+                .to_string(),
+        ),
+        other => Err(format!(
+            "LAGO_AGENT_API_URL must use https, got scheme `{other}`."
+        )),
+    }
+}
+
+// Builds the agent HTTP client. Redirects are disabled so a 3xx from the agent can never
+// forward X-LAGO-API-KEY to another host (reqwest does not strip custom headers across hosts
+// on redirect). With redirects off, a redirect surfaces as a non-2xx and is handled as an error.
+fn build_agent_client(timeout_secs: u64) -> reqwest::Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(Duration::from_secs(timeout_secs))
+        .build()
+}
+
 #[derive(Clone)]
 pub struct AnalyticsService;
 
@@ -151,16 +187,18 @@ impl AnalyticsService {
             ));
         }
 
+        // never forward the api key over an unencrypted channel to a non-loopback host
+        if let Err(msg) = validate_agent_url(&agent_url) {
+            return Ok(error_result(msg));
+        }
+
         // operators can tune the timeout; fall back to a sane default on unset/garbage input
         let timeout_secs = env::var("LAGO_AGENT_TIMEOUT_SECS")
             .ok()
             .and_then(|raw| raw.parse::<u64>().ok())
             .unwrap_or(DEFAULT_AGENT_TIMEOUT_SECS);
 
-        let client = match reqwest::Client::builder()
-            .timeout(Duration::from_secs(timeout_secs))
-            .build()
-        {
+        let client = match build_agent_client(timeout_secs) {
             Ok(client) => client,
             Err(e) => return Ok(error_result(format!("Failed to build HTTP client: {e}"))),
         };
@@ -304,5 +342,54 @@ mod tests {
         assert!(result.is_err());
         let ctr = result.unwrap_err();
         assert_eq!(ctr.is_error, Some(true));
+    }
+
+    #[tokio::test]
+    async fn call_agent_does_not_follow_redirects() {
+        // a 3xx from the agent must NOT be followed (reqwest would forward the custom
+        // X-LAGO-API-KEY header to the redirect target). With redirects disabled the 3xx
+        // surfaces as a non-2xx error instead. Regression guard for the key-leak fix.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/ask"))
+            .respond_with(
+                ResponseTemplate::new(307).insert_header("location", "https://evil.example/steal"),
+            )
+            .mount(&server)
+            .await;
+
+        let client = build_agent_client(30).expect("client builds");
+        let body = AgentAskRequest {
+            question: "q".to_string(),
+            session_id: None,
+        };
+
+        let result = call_agent(&client, &server.uri(), "secret-key", &body).await;
+
+        let error = result.expect_err("redirect must be treated as an error, not followed");
+        assert_eq!(error.is_error, Some(true));
+    }
+
+    #[test]
+    fn validate_agent_url_accepts_https() {
+        assert!(validate_agent_url("https://agent.getlago.com").is_ok());
+        assert!(validate_agent_url("https://agent.getlago.com/").is_ok());
+    }
+
+    #[test]
+    fn validate_agent_url_accepts_plaintext_loopback_for_dev() {
+        assert!(validate_agent_url("http://localhost:8080").is_ok());
+        assert!(validate_agent_url("http://127.0.0.1:8080").is_ok());
+    }
+
+    #[test]
+    fn validate_agent_url_rejects_plaintext_remote() {
+        assert!(validate_agent_url("http://agent.getlago.com").is_err());
+    }
+
+    #[test]
+    fn validate_agent_url_rejects_non_http_scheme_and_garbage() {
+        assert!(validate_agent_url("ftp://agent.getlago.com").is_err());
+        assert!(validate_agent_url("not a url").is_err());
     }
 }

--- a/mcp/src/tools/analytics.rs
+++ b/mcp/src/tools/analytics.rs
@@ -1,4 +1,4 @@
-// APPROVED SECURITY EXCEPTION (see CLAUDE.md):
+// APPROVED SECURITY EXCEPTION:
 //
 // Every other tool in this crate reaches data through `lago-client` -> Lago Rails,
 // and the `X-LAGO-API-KEY` is only ever forwarded to Rails. This tool is an


### PR DESCRIPTION
## Summary

Adds one MCP tool, **`ask_lago_analytics`**, to the Lago MCP server. It forwards a natural-language question to the first-party Lago analytics agent (`POST {LAGO_AGENT_API_URL}/ask`), forwarding the `X-LAGO-API-KEY`, and returns the agent's generated read-only SQL, a plain-language explanation, and a results table rendered as Markdown.

This is **Phase 2** of the MCP-wrap-of-agent initiative. Phase 1 (the Python agent's `POST /ask` endpoint, with `X-LAGO-API-KEY` → org resolution + RLS) shipped in `getlago/lago-data#456`.

- Supports multi-turn refinement: the response embeds a `session_id` in a JSON block; passing it back on a follow-up call reuses the agent's cached rows instead of re-querying.
- Clean, testable design: a pure `render_markdown`, a context-free `call_agent` (wiremock-tested), and a thin `ask` glue that reuses the existing `get_lago_api_config` dual-mode key resolution (header in HTTP/SSE, `LAGO_API_KEY` env in stdio).
- Docs updated (README Analytics section + example prompts + docker env note), `.env.development.example` gains `LAGO_AGENT_API_URL` and `LAGO_AGENT_TIMEOUT_SECS`, version bumped `0.1.0` → `0.2.0`.

## ⚠️ Approved security-model exception

This repo's `CLAUDE.md` mandates that all tool data access route through `lago-client` → Rails and that the API key be forwarded only to Rails. **`ask_lago_analytics` is an intentional, team-approved exception** (documented in a top-of-file comment in `analytics.rs`): it calls the first-party analytics agent directly via `reqwest`.

Org-isolation is preserved — the agent re-validates the `X-LAGO-API-KEY` against Lago REST and applies the same per-organization row-level security against a read-only analytical replica. The key is forwarded **only** to `{LAGO_AGENT_API_URL}/ask`, is never logged, and never appears in any tool response. The divergence is limited to this one tool; no other `.rs` files change behavior.

If reviewers want this routed through Rails instead (a `lago-api` proxy endpoint), that's a larger cross-repo change we can discuss — flagged here for visibility per `CLAUDE.md`.

## Files

- `mcp/src/tools/analytics.rs` (new) — `AnalyticsService`, `AskParams`, `render_markdown`, `call_agent`, 6 unit/wiremock tests
- `mcp/src/tools.rs` — `pub mod analytics;`
- `mcp/src/server.rs` — import, struct field, `new()`, `#[tool]` registration
- `mcp/Cargo.toml` / `Cargo.lock` — `wiremock` dev-dep, version `0.2.0`
- `README.md`, `mcp/.env.development.example` — docs

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` / `cargo test --all-features` — 6 analytics tests pass (incl. an `X-LAGO-API-KEY`-forwarding wiremock guard, a non-2xx path, and a malformed-body path)
- [x] `cargo check --release` — clean
- [ ] Smoke test against a running Phase-1 agent (manual, needs a reachable agent URL + staging key — per `docs/adding-new-tool.md` Phase 4 step 9)

## Out of scope (follow-ups per `docs/adding-new-tool.md`)

- **Phase 5/6**: staging + production MCP deploy, and the **manual Mistral console schema paste** (the tool isn't usable in the assistant until its schema is pasted into the agent's function list).
- The standard lago-types/lago-client crates.io publishes do **not** apply here — this tool deliberately does not go through `lago-client`.
