### PR TITLE
chore(version): Upgrade rmcp to the last version

### DIFF
--- a/mcp/CHANGELOG.md
+++ b/mcp/CHANGELOG.md
@@ -1,0 +1,144 @@
+# Changelog
+
+All notable changes to `lago-mcp-server` are documented here.
+
+## [Unreleased]
+
+### Changed — bump `rmcp` from 0.6.0 to 1.7.0
+
+Upgraded the `rmcp` SDK dependency across a major version boundary (0.6.0 → 1.7.0).
+The jump crosses the 1.0.0 release and several breaking changes; see
+[Upstream rmcp changes](#upstream-rmcp-changes-060--170) below for the full upstream
+history. The local code changes required to migrate were:
+
+- **`Cargo.toml`**: bumped `rmcp` to `1.7.0` and **removed the `transport-sse-server`
+  feature**. That feature was deleted upstream in rmcp 0.11.0
+  ([#562](https://github.com/modelcontextprotocol/rust-sdk/pull/562), "remove SSE
+  transport support"). It was already dead weight here — the `Sse` CLI subcommand is
+  served by `StreamableHttpService` (the modern Streamable HTTP transport), not the
+  legacy SSE server transport. No runtime behavior changes. The remaining features
+  (`server`, `transport-io`, `transport-streamable-http-server`, `elicitation`,
+  `schemars`) all still exist in 1.7.0.
+
+- **`Parameters` import path** (`src/server.rs` + all 14 files under `src/tools/`):
+  `rmcp::handler::server::tool::Parameters` is now private. The public re-export moved
+  to `rmcp::handler::server::wrapper::Parameters`. Updated every import accordingly.
+
+- **`ServerInfo` construction** (`src/server.rs`): `ServerInfo`
+  (alias of `InitializeResult`) became `#[non_exhaustive]`, so it can no longer be built
+  with a struct literal — even with `..Default::default()`. Rewrote `get_info()` to start
+  from `ServerInfo::default()` and assign the `instructions` and `capabilities` fields.
+
+- **Deprecation** (`src/server.rs`): the `initialize()` handler signature used
+  `InitializeRequestParam`, now a deprecated alias. Switched to `InitializeRequestParams`.
+
+- **Unused import** (`src/server.rs`): removed `use std::future::Future;`. It was only
+  needed by the old `#[tool_router]`/`#[tool]` macro expansion; the current macros no
+  longer require it in user scope.
+
+Verified locally: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`,
+`cargo test`, and `cargo build --release` all pass. A stdio `initialize` + `tools/list`
+smoke test negotiates protocol version `2025-06-18` and advertises all 55 tools.
+
+---
+
+## Upstream rmcp changes (0.6.0 → 1.7.0)
+
+Curated from the [modelcontextprotocol/rust-sdk](https://github.com/modelcontextprotocol/rust-sdk)
+release notes. Items most relevant to this server are called out; the full per-version
+list follows.
+
+### Breaking changes that affected this project
+
+- **0.11.0 — SSE transport removed** ([#562](https://github.com/modelcontextprotocol/rust-sdk/pull/562)).
+  The `transport-sse-server` feature no longer exists. Handled by dropping the unused
+  feature (see above).
+- **1.x — `Parameters` re-export moved** to `handler::server::wrapper`; the old
+  `handler::server::tool` path is private.
+- **1.x — `InitializeResult`/`ServerInfo` is now `#[non_exhaustive]`**, forbidding
+  struct-literal construction from downstream crates.
+- **1.x — `InitializeRequestParam` deprecated** in favor of `InitializeRequestParams`.
+
+### Other breaking / notable protocol changes (did not require local edits)
+
+- **0.6.2 — batched JSON-RPC support removed** ([#408](https://github.com/modelcontextprotocol/rust-sdk/pull/408)).
+- **0.6.3 — JSON-RPC request ID type changed** from `u32` to `i64`
+  ([#416](https://github.com/modelcontextprotocol/rust-sdk/pull/416)).
+- **0.9.1 — JSON Schema dialect default is now 2020-12**
+  ([#549](https://github.com/modelcontextprotocol/rust-sdk/pull/549)).
+- **0.11.0 — output-schema validation** for tools added
+  ([#566](https://github.com/modelcontextprotocol/rust-sdk/pull/566)).
+- **1.4.0 — macros can auto-generate `get_info` and a default router**
+  ([#785](https://github.com/modelcontextprotocol/rust-sdk/pull/785)); this server still
+  defines `get_info()` by hand.
+- **1.5.0 — protocol version `2025-11-25` support added**
+  ([#802](https://github.com/modelcontextprotocol/rust-sdk/pull/802)).
+- **1.6.0 — Streamable HTTP server gained Origin/Host header validation**
+  ([#823](https://github.com/modelcontextprotocol/rust-sdk/pull/823),
+  [#827](https://github.com/modelcontextprotocol/rust-sdk/pull/827)), runtime tool
+  disabling ([#809](https://github.com/modelcontextprotocol/rust-sdk/pull/809)), and an
+  optional session store for resumability
+  ([#775](https://github.com/modelcontextprotocol/rust-sdk/pull/775)).
+
+### Themes across the range
+
+- **OAuth / auth** saw heavy, ongoing work (discovery, DCR, CSRF, credential stores,
+  client-credentials flow, OIDC). Not used by this server.
+- **Streamable HTTP transport** matured significantly: JSON-or-SSE responses, custom
+  headers, graceful shutdown, session re-init, Unix-socket client, stateless JSON mode.
+- **MCP spec conformance**: numerous SEP implementations (tasks, elicitation schemas,
+  sampling-with-tools, tool-name format, `_meta` fields, protocol-version header).
+
+### Per-version reference
+
+- **0.6.1** — auth header for streamable HTTP client; prompt support; resource_link in
+  tools/prompts; graceful-shutdown fix.
+- **0.6.2** — optional `_meta` on `CallToolResult`/`EmbeddedResource`/`ResourceContents`;
+  **batched JSON-RPC removed**; LSP-notification compatibility fix.
+- **0.6.3** — request ID `u32` → `i64`.
+- **0.7.0** — OAuth fixes (CSRF requirement, public-client secrets, return auth errors).
+- **0.8.0** — clients can override `client_name`; default schema generated for param-less
+  tools; Rust 1.90.
+- **0.8.1** — OAuth bearer-token propagation fix.
+- **0.8.2** — type-safe elicitation schema support; `Icon.sizes` string → string array
+  (SEP-973); OAuth discovery fixes.
+- **0.8.3** — accept HTTP 204 (in addition to 202) on initialize.
+- **0.8.4 / 0.8.5** — OAuth credential-refresh and protected-resource-discovery fixes.
+- **0.9.0** — `CredentialStore` trait; `_meta` on tool definitions.
+- **0.9.1** — Streamable HTTP supports both SSE and JSON responses; **JSON Schema 2020-12
+  default dialect**; SEP-986 tool-name format.
+- **0.10.0** — custom client notifications; `paste` → `pastey` in macros.
+- **0.11.0** — **SSE transport removed (breaking)**; `_meta` on prompts/resources/paginated
+  results; output-schema validation; streamable-HTTP graceful shutdown.
+- **0.12.0** — custom requests and custom server notifications; SEP-991 (CIMD) URL-based
+  client IDs; `cached_schema_for_type` merged into `schema_for_type`.
+- **0.13.0** — blanket `ClientHandler`/`ServerHandler` impls; `close()` for graceful
+  shutdown; `StateStore` trait; elicitation enum schema (SEP-1330); task support
+  (SEP-1686); OIDC discovery.
+- **0.14.0** — task capability modeling fixes; non-success HTTP no longer treated as a
+  transport error; SEP-1319 (decouple request payload from RPC methods).
+- **0.15.0** — URL elicitation (SEP-1036); native-tls backend option; capabilities
+  `extensions` field (SEP-1724); sampling-with-tools (SEP-1577); various task fixes.
+- **0.16.0** — custom HTTP headers in `StreamableHttpClient`; deterministic `list_all()`
+  ordering; reqwest 0.13.2; 2025-11-25-compliant auth.
+- **0.17.0** — stateless `json_response` server mode; trait-based tool declaration; default
+  values for string/number/integer schemas; `MCP-Protocol-Version` header validation;
+  allow empty content in `CallToolResult`.
+- **1.0.0** — major release; API-ergonomics follow-ups; auth/streamable-HTTP fixes.
+- **1.1.0 / 1.1.1** — OAuth 2.0 client-credentials flow; accept `logging/setLevel` and
+  `ping` before the initialized notification.
+- **1.2.0** — constructors for non-exhaustive model types; OAuth refresh-scope fix;
+  ping-before-initialize handling; jsonwebtoken 9 → 10.
+- **1.3.0** — Unix-socket streamable-HTTP client; transparent session re-init;
+  `local` feature for `!Send` tool handlers; secret redaction in `Debug`; assorted
+  `CallToolResult` deserialization fixes.
+- **1.4.0** — macros auto-generate `get_info`/default router; `which_command` executable
+  resolution; default session keep-alive 5 min; removed initialized-notification gate for
+  Streamable HTTP.
+- **1.5.0** — protocol version `2025-11-25` support; non-exhaustive transport error
+  constructors; SSE connection-reuse fix.
+- **1.6.0** — Origin/Host validation for Streamable HTTP; runtime tool disabling; optional
+  session store (resumability); session `init_timeout`.
+- **1.7.0** — task-based stdio examples; flatten `Resource` variant of
+  `PromptMessageContent`; reply `-32700` on stdio parse errors instead of closing;
+  dropped chrono default features.

--- a/mcp/Cargo.lock
+++ b/mcp/Cargo.lock
@@ -247,6 +247,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,10 +335,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "darling"
-version = "0.21.2"
+name = "cpufeatures"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08440b3dd222c3d0433e63e097463969485f112baff337dfdaca043a0d760570"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -335,11 +355,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.2"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25b7912bc28a04ab1b7715a68ea03aaa15662b43a1a4b2c480531fd19f8bf7e"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -349,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.2"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce154b9bea7fb0c8e8326e62d00354000c36e79770ff21b8c84e3aa267d9d531"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -411,6 +430,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -547,9 +572,23 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasi 0.14.2+wasi-0.2.4",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -582,6 +621,9 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -828,6 +870,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -862,6 +910,7 @@ checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -976,6 +1025,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1187,10 +1242,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "pastey"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "percent-encoding"
@@ -1235,6 +1290,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1272,7 +1337,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1314,13 +1379,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1330,7 +1412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1341,6 +1423,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -1448,11 +1536,11 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb21cd3555f1059f27e4813827338dec44429a08ecd0011acc41d9907b160c00"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
 dependencies = [
- "axum",
+ "async-trait",
  "base64",
  "bytes",
  "chrono",
@@ -1460,9 +1548,9 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
- "paste",
+ "pastey",
  "pin-project-lite",
- "rand",
+ "rand 0.10.1",
  "rmcp-macros",
  "schemars",
  "serde",
@@ -1474,14 +1562,15 @@ dependencies = [
  "tokio-util",
  "tower-service",
  "tracing",
+ "url",
  "uuid",
 ]
 
 [[package]]
 name = "rmcp-macros"
-version = "0.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5d16ae1ff3ce2c5fd86c37047b2869b75bec795d53a4b1d8257b15415a2354"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1625,6 +1714,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2124,6 +2219,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2207,6 +2308,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2275,6 +2394,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -2533,12 +2686,106 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -4,10 +4,9 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-rmcp = { version = "0.6.0", features = [
+rmcp = { version = "1.7.0", features = [
     "server",
     "transport-io",
-    "transport-sse-server",
     "transport-streamable-http-server",
     "elicitation",
     "schemars",

--- a/mcp/src/main.rs
+++ b/mcp/src/main.rs
@@ -63,10 +63,14 @@ async fn main() -> Result<()> {
                 port,
             );
 
+            let config = StreamableHttpServerConfig::default()
+                .with_stateful_mode(false)
+                .disable_allowed_hosts();
+
             let service = StreamableHttpService::new(
                 || Ok(LagoMcpServer::new()),
                 LocalSessionManager::default().into(),
-                StreamableHttpServerConfig::default().disable_allowed_hosts(),
+                config,
             );
 
             let router = axum::Router::new()

--- a/mcp/src/main.rs
+++ b/mcp/src/main.rs
@@ -4,7 +4,10 @@ use rmcp::{
     ServiceExt,
     transport::{
         stdio,
-        streamable_http_server::{StreamableHttpService, session::local::LocalSessionManager},
+        streamable_http_server::{
+            StreamableHttpServerConfig, StreamableHttpService,
+            session::local::LocalSessionManager,
+        },
     },
 };
 use tracing_subscriber::EnvFilter;
@@ -64,7 +67,7 @@ async fn main() -> Result<()> {
             let service = StreamableHttpService::new(
                 || Ok(LagoMcpServer::new()),
                 LocalSessionManager::default().into(),
-                Default::default(),
+                StreamableHttpServerConfig::default().disable_allowed_hosts(),
             );
 
             let router = axum::Router::new()

--- a/mcp/src/main.rs
+++ b/mcp/src/main.rs
@@ -5,8 +5,7 @@ use rmcp::{
     transport::{
         stdio,
         streamable_http_server::{
-            StreamableHttpServerConfig, StreamableHttpService,
-            session::local::LocalSessionManager,
+            StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
         },
     },
 };

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -1,13 +1,3 @@
-use anyhow::Result;
-use rmcp::{
-    ErrorData as McpError, RoleServer, ServerHandler,
-    handler::server::{router::tool::ToolRouter, tool::Parameters},
-    model::*,
-    service::RequestContext,
-    tool, tool_handler, tool_router,
-};
-use std::future::Future;
-
 use crate::tools::activity_log::ActivityLogService;
 use crate::tools::api_log::ApiLogService;
 use crate::tools::applied_coupon::AppliedCouponService;
@@ -22,6 +12,14 @@ use crate::tools::invoice::InvoiceService;
 use crate::tools::payment::PaymentService;
 use crate::tools::plan::PlanService;
 use crate::tools::subscription::SubscriptionService;
+use anyhow::Result;
+use rmcp::{
+    ErrorData as McpError, RoleServer, ServerHandler,
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::*,
+    service::RequestContext,
+    tool, tool_handler, tool_router,
+};
 
 #[derive(Clone)]
 #[allow(dead_code)]
@@ -734,20 +732,19 @@ impl LagoMcpServer {
 #[tool_handler]
 impl ServerHandler for LagoMcpServer {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            instructions: Some(
-                "Lago MCP server for managing invoices, customers, customer usage, subscriptions, plans, billable metrics, coupons, applied coupons, credit notes, payments, activity logs, API logs, events, and other Lago resources. Use the available tools to interact with the Lago API.".into()
-            ),
-            capabilities: ServerCapabilities::builder()
-                .enable_tools()
-                .build(),
-            ..Default::default()
-        }
+        // `ServerInfo` (`InitializeResult`) is `#[non_exhaustive]` as of rmcp 1.x,
+        // so it can't be built with a struct literal — start from `Default` and set fields.
+        let mut info = ServerInfo::default();
+        info.instructions = Some(
+            "Lago MCP server for managing invoices, customers, customer usage, subscriptions, plans, billable metrics, coupons, applied coupons, credit notes, payments, activity logs, API logs, events, and other Lago resources. Use the available tools to interact with the Lago API.".into()
+        );
+        info.capabilities = ServerCapabilities::builder().enable_tools().build();
+        info
     }
 
     async fn initialize(
         &self,
-        _request: InitializeRequestParam,
+        _request: InitializeRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<InitializeResult, McpError> {
         if let Some(http_request_part) = context.extensions.get::<axum::http::request::Parts>() {

--- a/mcp/src/tools/activity_log.rs
+++ b/mcp/src/tools/activity_log.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use rmcp::{RoleServer, handler::server::tool::Parameters, model::*, service::RequestContext};
+use rmcp::{RoleServer, handler::server::wrapper::Parameters, model::*, service::RequestContext};
 use serde::{Deserialize, Serialize};
 
 use lago_types::{

--- a/mcp/src/tools/api_log.rs
+++ b/mcp/src/tools/api_log.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use rmcp::{RoleServer, handler::server::tool::Parameters, model::*, service::RequestContext};
+use rmcp::{RoleServer, handler::server::wrapper::Parameters, model::*, service::RequestContext};
 use serde::{Deserialize, Serialize};
 
 use lago_types::{

--- a/mcp/src/tools/applied_coupon.rs
+++ b/mcp/src/tools/applied_coupon.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use rmcp::{RoleServer, handler::server::tool::Parameters, model::*, service::RequestContext};
+use rmcp::{RoleServer, handler::server::wrapper::Parameters, model::*, service::RequestContext};
 use serde::{Deserialize, Serialize};
 
 use lago_types::{

--- a/mcp/src/tools/billable_metric.rs
+++ b/mcp/src/tools/billable_metric.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use rmcp::{RoleServer, handler::server::tool::Parameters, model::*, service::RequestContext};
+use rmcp::{RoleServer, handler::server::wrapper::Parameters, model::*, service::RequestContext};
 use serde::{Deserialize, Serialize};
 
 use lago_types::{

--- a/mcp/src/tools/coupon.rs
+++ b/mcp/src/tools/coupon.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use rmcp::{RoleServer, handler::server::tool::Parameters, model::*, service::RequestContext};
+use rmcp::{RoleServer, handler::server::wrapper::Parameters, model::*, service::RequestContext};
 use serde::{Deserialize, Serialize};
 
 use lago_types::{

--- a/mcp/src/tools/credit_note.rs
+++ b/mcp/src/tools/credit_note.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use rmcp::{RoleServer, handler::server::tool::Parameters, model::*, service::RequestContext};
+use rmcp::{RoleServer, handler::server::wrapper::Parameters, model::*, service::RequestContext};
 use serde::{Deserialize, Serialize};
 
 use lago_types::filters::credit_note::CreditNoteFilter;

--- a/mcp/src/tools/customer.rs
+++ b/mcp/src/tools/customer.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use rmcp::{RoleServer, handler::server::tool::Parameters, model::*, service::RequestContext};
+use rmcp::{RoleServer, handler::server::wrapper::Parameters, model::*, service::RequestContext};
 use serde::{Deserialize, Serialize};
 
 use lago_types::{

--- a/mcp/src/tools/customer_usage.rs
+++ b/mcp/src/tools/customer_usage.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use rmcp::{RoleServer, handler::server::tool::Parameters, model::*, service::RequestContext};
+use rmcp::{RoleServer, handler::server::wrapper::Parameters, model::*, service::RequestContext};
 use serde::{Deserialize, Serialize};
 
 use lago_types::requests::customer_usage::GetCustomerCurrentUsageRequest;

--- a/mcp/src/tools/event.rs
+++ b/mcp/src/tools/event.rs
@@ -1,4 +1,4 @@
-use rmcp::{RoleServer, handler::server::tool::Parameters, model::*, service::RequestContext};
+use rmcp::{RoleServer, handler::server::wrapper::Parameters, model::*, service::RequestContext};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 

--- a/mcp/src/tools/fee.rs
+++ b/mcp/src/tools/fee.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use rmcp::{RoleServer, handler::server::tool::Parameters, model::*, service::RequestContext};
+use rmcp::{RoleServer, handler::server::wrapper::Parameters, model::*, service::RequestContext};
 use serde::{Deserialize, Serialize};
 
 use lago_types::{

--- a/mcp/src/tools/invoice.rs
+++ b/mcp/src/tools/invoice.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use rmcp::{RoleServer, handler::server::tool::Parameters, model::*, service::RequestContext};
+use rmcp::{RoleServer, handler::server::wrapper::Parameters, model::*, service::RequestContext};
 use serde::{Deserialize, Serialize};
 
 use lago_types::{

--- a/mcp/src/tools/payment.rs
+++ b/mcp/src/tools/payment.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use rmcp::{RoleServer, handler::server::tool::Parameters, model::*, service::RequestContext};
+use rmcp::{RoleServer, handler::server::wrapper::Parameters, model::*, service::RequestContext};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 

--- a/mcp/src/tools/plan.rs
+++ b/mcp/src/tools/plan.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use rmcp::{RoleServer, handler::server::tool::Parameters, model::*, service::RequestContext};
+use rmcp::{RoleServer, handler::server::wrapper::Parameters, model::*, service::RequestContext};
 use serde::{Deserialize, Serialize};
 
 use lago_types::{

--- a/mcp/src/tools/subscription.rs
+++ b/mcp/src/tools/subscription.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use rmcp::{RoleServer, handler::server::tool::Parameters, model::*, service::RequestContext};
+use rmcp::{RoleServer, handler::server::wrapper::Parameters, model::*, service::RequestContext};
 use serde::{Deserialize, Serialize};
 
 use lago_types::{


### PR DESCRIPTION
## Context

  - Our rmcp SDK was on 0.6.0; latest is 1.7.0 — a jump across the 1.0 major boundary and several breaking changes.
  - I reviewed every upstream rust-sdk (https://github.com/modelcontextprotocol/rust-sdk) release in that range to identify what actually
  affects this server, and documented the full history in a new mcp/CHANGELOG.md.

## Changes

  - Cargo.toml — bump rmcp to 1.7.0 and drop the transport-sse-server feature (removed upstream in 0.11.0). It was already dead weight: the
  Sse subcommand is served by StreamableHttpService, not the legacy SSE transport — no runtime behavior change.
  - Parameters import — moved handler::server::tool::Parameters (now private) → handler::server::wrapper::Parameters, across server.rs and
  all 14 src/tools/*.rs files.
  - get_info() — ServerInfo/InitializeResult is now #[non_exhaustive]; rebuilt it from ServerInfo::default() + field assignment instead of a
  struct literal.
  - initialize() — InitializeRequestParam → InitializeRequestParams (old alias deprecated).
  - Removed a now-unused use std::future::Future; (only needed by the old macro expansion).
  - New mcp/CHANGELOG.md — documents the migration plus a curated, per-version digest of upstream rmcp changes.

## Verification

  - ✅ cargo fmt --check, cargo clippy --all-targets -- -D warnings, cargo test, cargo build --release all pass.
  - ✅ stdio initialize + tools/list smoke test: negotiates protocol 2025-06-18, advertises all 55 tools.