### PR TITLE
mcp: allow plaintext http to the in-cluster agent (*.svc.cluster.local)

### DIFF
--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lago-mcp-server"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 
 [dependencies]

--- a/mcp/src/tools/analytics.rs
+++ b/mcp/src/tools/analytics.rs
@@ -123,8 +123,13 @@ async fn call_agent(
         .map_err(|e| error_result(format!("Failed to parse agent response: {e}")))
 }
 
-// We forward X-LAGO-API-KEY to the agent, so require an encrypted channel. Plaintext
-// http:// is allowed only for loopback hosts (local dev / self-hosted on the same box).
+// We forward X-LAGO-API-KEY to the agent, so require an encrypted channel by default.
+// Plaintext http:// is allowed only where the traffic never leaves a trusted boundary:
+//   - loopback hosts (local dev / self-hosted on the same box), and
+//   - in-cluster Kubernetes service DNS (`*.svc.cluster.local`), where the call is
+//     pod-to-pod inside the cluster network — the standard service-to-service transport.
+//     The cloud deployment reaches the agent at
+//     `lago-data-agent.lago-data-agent.svc.cluster.local`, which is never publicly routable.
 // We deliberately do NOT pin a host allowlist: LAGO_AGENT_API_URL is operator-controlled
 // deployment config and self-hosted operators run their own analytics agent host.
 fn validate_agent_url(raw: &str) -> Result<(), String> {
@@ -135,12 +140,18 @@ fn validate_agent_url(raw: &str) -> Result<(), String> {
         url.host_str(),
         Some("localhost") | Some("127.0.0.1") | Some("::1") | Some("[::1]")
     );
+    // the leading dot is load-bearing: it keeps public lookalikes like
+    // `evilsvc.cluster.local` or `x.svc.cluster.local.evil.com` from matching.
+    let host_is_cluster_internal = url
+        .host_str()
+        .is_some_and(|host| host.ends_with(".svc.cluster.local"));
 
     match url.scheme() {
         "https" => Ok(()),
-        "http" if host_is_loopback => Ok(()),
+        "http" if host_is_loopback || host_is_cluster_internal => Ok(()),
         "http" => Err(
-            "LAGO_AGENT_API_URL must use https; plaintext http is only allowed for localhost."
+            "LAGO_AGENT_API_URL must use https; plaintext http is only allowed for \
+             localhost or in-cluster *.svc.cluster.local hosts."
                 .to_string(),
         ),
         other => Err(format!(
@@ -383,8 +394,21 @@ mod tests {
     }
 
     #[test]
+    fn validate_agent_url_accepts_plaintext_in_cluster_service_dns() {
+        // the cloud deployment reaches the agent over pod-to-pod cluster DNS, which is
+        // plaintext http by convention; this must be allowed or the in-cluster call fails.
+        assert!(
+            validate_agent_url("http://lago-data-agent.lago-data-agent.svc.cluster.local").is_ok()
+        );
+        assert!(validate_agent_url("http://foo.bar.svc.cluster.local:8000").is_ok());
+    }
+
+    #[test]
     fn validate_agent_url_rejects_plaintext_remote() {
         assert!(validate_agent_url("http://agent.getlago.com").is_err());
+        // lookalikes must not slip through the cluster-internal carve-out
+        assert!(validate_agent_url("http://evil.com/path.svc.cluster.local").is_err());
+        assert!(validate_agent_url("http://evilsvc.cluster.local").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Why

The `ask_lago_analytics` tool (added in #55) validates `LAGO_AGENT_API_URL` and currently allows plaintext `http://` **only for loopback** (`localhost`/`127.0.0.1`), requiring `https` for every other host.

But the deployed topology reaches the agent over **in-cluster Kubernetes service DNS** — `http://lago-data-agent.lago-data-agent.svc.cluster.local` (Max confirmed; the agent is internal-only and not publicly exposed). That URL is `http` + a non-loopback host, so the current validator **rejects it**:

> `LAGO_AGENT_API_URL must use https; plaintext http is only allowed for localhost.`

This blocks wiring the staging MCP server to the agent. A service mesh doing transparent mTLS wouldn't help either — the app still *sees* an `http://` scheme and the validator rejects it.

## What

Extend `validate_agent_url` to also allow plaintext `http://` for **in-cluster service DNS** (hosts ending in `.svc.cluster.local`), alongside the existing loopback exception. Everything else still requires `https`.

The rationale matches the existing loopback carve-out: plaintext is allowed only where traffic **never leaves a trusted boundary** — same box (loopback) or pod-to-pod inside the cluster network (`*.svc.cluster.local`), which is the standard k8s service-to-service transport and is never publicly routable. Public hosts still require TLS because that's where the `X-LAGO-API-KEY` would actually cross an untrusted network.

The leading dot in the suffix match is deliberate — it keeps public lookalikes (`evilsvc.cluster.local`, `x.svc.cluster.local.evil.com`, or a `.svc.cluster.local` path on a public host) from matching. Tests cover both the accept and the lookalike-reject cases.

Scope note: this covers the default cluster domain (`*.svc.cluster.local`). A custom cluster domain or a private-IP agent host would still need `https` (or a follow-up) — kept tight intentionally.

## Tests

- `validate_agent_url_accepts_plaintext_in_cluster_service_dns` — the deployment URL + a `:port` variant pass.
- `validate_agent_url_rejects_plaintext_remote` — strengthened: `http://agent.getlago.com`, `http://evil.com/path.svc.cluster.local`, and `http://evilsvc.cluster.local` all still rejected.
- Full local CI bar green: `fmt --check`, `clippy --all-targets -D warnings`, `cargo test` (12 analytics tests), `cargo check --release`.

Version bumped `0.2.0` → `0.2.1`.

## Follow-up (separate, infra)

Once merged + image built, point staging at the new image and set the env in `getlago/lago-deploy/staging/mcp-server-values.yaml`:
- `image.tag` → the new build's `sha-...`
- `extraEnv: [{ name: LAGO_AGENT_API_URL, value: http://lago-data-agent.lago-data-agent.svc.cluster.local }]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)