### PR TITLE
feat(invoices): add action to delete a draft invoice

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ For self-hosted Lago, replace `LAGO_API_URL` with your instance URL.
 ### Invoices
 - **`find_invoice_by_number`**: Find an invoice by its number (e.g., "RAF-8142-202601-312") and get its Lago ID
 - **`get_invoice`**: Retrieve a specific invoice by Lago ID
+- **`delete_invoice`**: Delete a draft invoice by Lago ID after confirming the action; this cannot be undone
 - **`list_invoices`**: Search and filter invoices with advanced criteria
 - **`list_customer_invoices`**: List all invoices for a specific customer
 - **`create_invoice`**: Create a one-off invoice with add-on fees

--- a/mcp/Cargo.lock
+++ b/mcp/Cargo.lock
@@ -998,9 +998,9 @@ dependencies = [
 
 [[package]]
 name = "lago-client"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64cf88fc6bc4bf34f62089d10dccb82c5577601de861b818bf9346be4166cb6"
+checksum = "045252665bada82f2bd361f2efab7d1d20b9a929eef02e450a3780dfc3e74c24"
 dependencies = [
  "anyhow",
  "lago-types",
@@ -1041,9 +1041,9 @@ dependencies = [
 
 [[package]]
 name = "lago-types"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d484cc75281cf030334eb5b05ec21cb16e85a29f5f2046f494ae8c9e6c9482"
+checksum = "102fd09f955985d2b135adc3639998fe9aa04dea8cb8e1a8590edd89237cb707"
 dependencies = [
  "chrono",
  "reqwest",

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -22,8 +22,8 @@ async-trait = "0.1"
 schemars = { version = "1.0", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-lago-client = "0.1.25"
-lago-types = "0.1.23"
+lago-client = "0.1.26"
+lago-types = "0.1.24"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 urlencoding = "2.1"
 clap = { version = "4.5", features = ["derive"] }

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -97,7 +97,22 @@ impl LagoMcpServer {
     }
 
     #[tool(
-        description = "Find an invoice by its number (e.g., 'RAF-8142-202601-312'). Use this when you have an invoice number and need to find the invoice details or its lago_id for other operations like voiding."
+        description = "Delete a draft invoice by its Lago ID (UUID). Use this only when an invoice was created by mistake and is still in draft status. \
+            The deletion cannot be undone: the invoice disappears from Lago, its usage is not carried to the next billing period, and any attached draft credit note is also deleted. \
+            Confirm the user's intent before calling this tool. If you only have an invoice number, use find_invoice_by_number first."
+    )]
+    pub async fn delete_invoice(
+        &self,
+        parameters: Parameters<crate::tools::invoice::DeleteInvoiceArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        self.invoice_service
+            .delete_invoice(parameters, context)
+            .await
+    }
+
+    #[tool(
+        description = "Find an invoice by its number (e.g., 'RAF-8142-202601-312'). Use this when you have an invoice number and need to find the invoice details or its lago_id for other operations like deleting a draft or voiding a finalized invoice."
     )]
     pub async fn find_invoice_by_number(
         &self,

--- a/mcp/src/tools/invoice.rs
+++ b/mcp/src/tools/invoice.rs
@@ -7,10 +7,10 @@ use lago_types::{
     models::{InvoicePaymentStatus, InvoiceStatus, InvoiceType, PaginationParams},
     requests::invoice::{
         BillingTime, CreateInvoiceFeeInput, CreateInvoiceInput, CreateInvoiceRequest,
-        DownloadInvoiceRequest, GetInvoiceRequest, InvoicePreviewCoupon, InvoicePreviewCustomer,
-        InvoicePreviewInput, InvoicePreviewRequest, InvoicePreviewSubscriptions,
-        ListCustomerInvoicesRequest, ListInvoicesRequest, RefreshInvoiceRequest,
-        RetryInvoicePaymentRequest, RetryInvoiceRequest, UpdateInvoiceInput,
+        DeleteInvoiceRequest, DownloadInvoiceRequest, GetInvoiceRequest, InvoicePreviewCoupon,
+        InvoicePreviewCustomer, InvoicePreviewInput, InvoicePreviewRequest,
+        InvoicePreviewSubscriptions, ListCustomerInvoicesRequest, ListInvoicesRequest,
+        RefreshInvoiceRequest, RetryInvoicePaymentRequest, RetryInvoiceRequest, UpdateInvoiceInput,
         UpdateInvoiceMetadataInput, UpdateInvoiceRequest, VoidInvoiceRequest,
     },
 };
@@ -46,6 +46,13 @@ pub struct GetInvoiceArgs {
     /// The Lago ID (UUID) of the invoice. Note: This is NOT the invoice number.
     /// To find an invoice by its number (e.g., "RAF-8142-202601-312"), use find_invoice_by_number instead.
     pub invoice_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct DeleteInvoiceArgs {
+    /// The Lago ID (UUID) of the draft invoice to delete. This is not the invoice number.
+    /// Use find_invoice_by_number first if you only have an invoice number.
+    pub lago_id: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
@@ -298,6 +305,33 @@ impl InvoiceService {
         }
     }
 
+    pub async fn delete_invoice(
+        &self,
+        Parameters(args): Parameters<DeleteInvoiceArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let client = match create_lago_client(&context).await {
+            Ok(client) => client,
+            Err(error_result) => return Ok(error_result),
+        };
+        let request = DeleteInvoiceRequest::new(args.lago_id);
+
+        match client.delete_invoice(request).await {
+            Ok(response) => {
+                let result = serde_json::json!({
+                    "invoice": response.invoice,
+                });
+
+                Ok(success_result(&result))
+            }
+            Err(e) => {
+                let error_message = format!("Failed to delete draft invoice: {e}");
+                tracing::error!("{error_message}");
+                Ok(error_result(error_message))
+            }
+        }
+    }
+
     /// Find an invoice by its number (e.g., "RAF-8142-202601-312").
     /// Returns the invoice details including the lago_id (UUID) needed for other operations.
     pub async fn find_invoice_by_number(
@@ -327,7 +361,7 @@ impl InvoiceService {
                             "found": true,
                             "invoice": invoice,
                             "lago_id": invoice.lago_id,
-                            "hint": "Use the lago_id for operations like void_invoice, download_invoice, etc."
+                            "hint": "Use the lago_id for operations like delete_invoice, void_invoice, download_invoice, etc."
                         });
                         Ok(success_result(&result))
                     }


### PR DESCRIPTION
## Context

_Part of the "delete draft invoice" feature_

A new endpoint was added to delete a draft invoice (https://github.com/getlago/lago-api/pull/5968).
It was added to the rust api client (https://github.com/getlago/lago-rust-client/pull/55).

## Description

This PR adds a new `delete_invoice` MCP action to delete draft invoices.

The tool description makes it clear that the action only works for drafts and cannot be undone.
