### PR TITLE
docs: point install instructions at ghcr, not the dead Docker Hub image

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Repository context for Claude
 
-This repository (`getlago/lago-agent-toolkit`) is the Rust MCP server (`lago-mcp-server`) that exposes Lago billing operations as tools for AI agents. It's shipped as a Docker image (`getlago/lago-mcp-server`) consumed by both Claude Desktop and the Lago AI Assistant (via Mistral + a Ruby orchestration layer in `getlago/lago-api`).
+This repository (`getlago/lago-agent-toolkit`) is the Rust MCP server (`lago-mcp-server`) that exposes Lago billing operations as tools for AI agents. It's shipped as a Docker image (`ghcr.io/getlago/mcp-server`) consumed by both Claude Desktop and the Lago AI Assistant (via Mistral + a Ruby orchestration layer in `getlago/lago-api`).
 
 ## When the user wants to add a new MCP tool
 

--- a/README.md
+++ b/README.md
@@ -39,11 +39,12 @@ For operators deploying Managed Agents to their own customers and needing per-se
         "run",
         "--rm",
         "-i",
+        "--pull=always",
         "--name", "lago-mcp-server",
         "-e", "LAGO_API_KEY=your_lago_api_key",
         "-e", "LAGO_API_URL=https://api.getlago.com/api/v1",
         "-e", "LAGO_AGENT_API_URL=https://agent.getlago.com",
-        "getlago/lago-mcp-server:latest"
+        "ghcr.io/getlago/mcp-server:main"
       ]
     }
   }

--- a/docs/adding-new-tool.md
+++ b/docs/adding-new-tool.md
@@ -309,7 +309,7 @@ Goal: get the new MCP server image running in staging, and teach the staging Mis
 
 **Steps**:
 
-1. **MCP staging deploy**. The PR merge auto-triggers `.github/workflows/mcp-docker-build.yml`, which pushes a new `getlago/lago-mcp-server` image (typically tagged `:latest` plus a SHA tag). The deploy to staging is **separate** — usually owned by platform/SRE. Confirm in the relevant Slack channel (often `#platform` or `#infra` for Lago) that the new image is rolled out. Roll back is by redeploying the previous SHA tag, not by deleting the new one (`:latest` is mutable, so always reference SHAs for rollback safety).
+1. **MCP staging deploy**. The PR merge auto-triggers `.github/workflows/mcp-docker-build.yml`, which pushes a new `ghcr.io/getlago/mcp-server` image (tagged `:main` plus a `sha-<commit>` tag). The deploy to staging is **separate** — usually owned by platform/SRE. Confirm in the relevant Slack channel (often `#platform` or `#infra` for Lago) that the new image is rolled out. Roll back is by redeploying the previous SHA tag, not by deleting the new one (`:main` is mutable, so always reference SHAs for rollback safety).
 
 2. Verify the staging MCP server has the new tool. Either:
    - Ask the assistant a question that should trigger the tool — if you get `Tool '<name>' not found`, the deploy hasn't happened yet.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -941,10 +941,11 @@ Add the following to your Claude Desktop MCP configuration:
         "run",
         "--rm",
         "-i",
+        "--pull=always",
         "--name", "lago-mcp-server",
         "-e", "LAGO_API_KEY=your_lago_api_key",
         "-e", "LAGO_API_URL=https://api.getlago.com/api/v1",
-        "getlago/lago-mcp-server"
+        "ghcr.io/getlago/mcp-server:main"
       ]
     }
   }


### PR DESCRIPTION
The quickstart has told people to run `getlago/lago-mcp-server:latest` since the README was first written (ec90c84, 2025-07-22). Publishing moved to `ghcr.io/getlago/mcp-server` on 2025-11-14 (#14, adopting the shared build workflow), and Docker Hub has not been rebuilt since 2025-11-10.

That image advertises 8 tools. Anyone following the README got a server with no invoice mutations, no fees, coupons, credit notes, payments or logs — every tool added after #28 reads as available in the README and isn't. There is no error to debug either: the missing tools simply never appear in `tools/list`, so the agent says it can't do it and nothing is logged.

- README.md / mcp/README.md: ghcr image in both Claude Desktop snippets
- README.md: registry note, and `--pull=always` so a cached image can't silently freeze the tool catalogue again
- CLAUDE.md, docs/adding-new-tool.md: ghcr image name, `:main` not `:latest`

Verified: the command in the patched quickstart serves 57 tools including create_invoice.