### PR TITLE
feat(mcp): expose fee service period on create_invoice + make ghcr latest track main

### DIFF
--- a/.github/workflows/mcp-docker-build.yml
+++ b/.github/workflows/mcp-docker-build.yml
@@ -18,3 +18,8 @@ jobs:
       registry: ghcr
       context: mcp
       dockerfile: mcp/Dockerfile
+      # Without this, `latest` only moves on a semver tag push (metadata-action's
+      # latest=auto flavor), so it has pointed at 0.1.0 since Nov 2025 while every
+      # merge here only updated `main` and `sha-<commit>`.
+      tags: |
+        type=raw,value=latest,enable={{is_default_branch}}

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ For self-hosted Lago, replace `LAGO_API_URL` with your instance URL.
 - **`delete_invoice`**: Delete a draft invoice by Lago ID after confirming the action; this cannot be undone
 - **`list_invoices`**: Search and filter invoices with advanced criteria
 - **`list_customer_invoices`**: List all invoices for a specific customer
-- **`create_invoice`**: Create a one-off invoice with add-on fees
+- **`create_invoice`**: Create a one-off invoice with add-on fees, each optionally carrying a service period (`from_datetime` / `to_datetime`)
 - **`update_invoice`**: Update an invoice's payment status or metadata
 - **`preview_invoice`**: Preview an invoice before creating it
 - **`refresh_invoice`**: Refresh a draft invoice to recalculate charges

--- a/mcp/Cargo.lock
+++ b/mcp/Cargo.lock
@@ -1041,9 +1041,9 @@ dependencies = [
 
 [[package]]
 name = "lago-types"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "102fd09f955985d2b135adc3639998fe9aa04dea8cb8e1a8590edd89237cb707"
+checksum = "236ee8684a8031da12bb9424ead3a88f17b9dc9bc5611fd9db5e96fa23f16fb3"
 dependencies = [
  "chrono",
  "reqwest",

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -23,7 +23,7 @@ schemars = { version = "1.0", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 lago-client = "0.1.26"
-lago-types = "0.1.24"
+lago-types = "0.1.25"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 urlencoding = "2.1"
 clap = { version = "4.5", features = ["derive"] }

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -151,7 +151,9 @@ impl LagoMcpServer {
     }
 
     #[tool(
-        description = "Create a one-off invoice for a customer with add-on charges. Use this to bill customers for one-time fees like setup charges, consulting hours, or any non-recurring charges."
+        description = "Create a one-off invoice for a customer with add-on charges. Use this to bill customers for one-time fees like setup charges, consulting hours, or any non-recurring charges. \
+            Each fee can carry a service period describing the dates the charge covers, via `from_datetime` and `to_datetime` (ISO 8601 datetimes in UTC). \
+            The service period is optional, but both boundaries must be set together — sending only one is rejected."
     )]
     pub async fn create_invoice(
         &self,

--- a/mcp/src/tools/invoice.rs
+++ b/mcp/src/tools/invoice.rs
@@ -111,6 +111,29 @@ pub struct CreateInvoiceFeeArgs {
     pub description: Option<String>,
     /// Optional tax codes to apply to this fee.
     pub tax_codes: Option<Vec<String>>,
+    /// Start of the service period this fee covers, as an ISO 8601 datetime in UTC
+    /// (e.g. "2026-08-01T00:00:00Z"). Must be provided together with `to_datetime`.
+    pub from_datetime: Option<String>,
+    /// End of the service period this fee covers, as an ISO 8601 datetime in UTC
+    /// (e.g. "2026-08-31T23:59:59Z"). Must be provided together with `from_datetime`.
+    pub to_datetime: Option<String>,
+}
+
+/// The Lago API rejects a fee that carries only one service period boundary.
+/// Checked before the request is built so the model gets an actionable message
+/// instead of a 422 it can't interpret.
+fn validate_service_periods(fees: &[CreateInvoiceFeeArgs]) -> Result<(), String> {
+    for (index, fee) in fees.iter().enumerate() {
+        if fee.from_datetime.is_some() != fee.to_datetime.is_some() {
+            return Err(format!(
+                "Fee at index {index} (add_on_code '{}') sets only one of from_datetime / \
+                 to_datetime. A service period needs both boundaries, or neither.",
+                fee.add_on_code
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
@@ -530,6 +553,10 @@ impl InvoiceService {
         Parameters(args): Parameters<CreateInvoiceArgs>,
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
+        if let Err(message) = validate_service_periods(&args.fees) {
+            return Ok(error_result(message));
+        }
+
         let client = match create_lago_client(&context).await {
             Ok(client) => client,
             Err(error_result) => return Ok(error_result),
@@ -548,6 +575,9 @@ impl InvoiceService {
                 }
                 if let Some(taxes) = f.tax_codes {
                     fee = fee.with_tax_codes(taxes);
+                }
+                if let (Some(from), Some(to)) = (f.from_datetime, f.to_datetime) {
+                    fee = fee.with_service_period(from, to);
                 }
                 fee
             })
@@ -799,5 +829,53 @@ impl InvoiceService {
                 Ok(error_result(error_message))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fee(from: Option<&str>, to: Option<&str>) -> CreateInvoiceFeeArgs {
+        CreateInvoiceFeeArgs {
+            add_on_code: "setup_fee".to_string(),
+            units: 1.0,
+            unit_amount_cents: None,
+            description: None,
+            tax_codes: None,
+            from_datetime: from.map(str::to_string),
+            to_datetime: to.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn accepts_both_boundaries_or_neither() {
+        assert!(validate_service_periods(&[fee(None, None)]).is_ok());
+        assert!(
+            validate_service_periods(&[fee(
+                Some("2026-08-01T00:00:00Z"),
+                Some("2026-08-31T23:59:59Z")
+            )])
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn rejects_a_single_boundary() {
+        let err = validate_service_periods(&[fee(Some("2026-08-01T00:00:00Z"), None)]).unwrap_err();
+        assert!(err.contains("index 0"));
+        assert!(err.contains("setup_fee"));
+
+        assert!(validate_service_periods(&[fee(None, Some("2026-08-31T23:59:59Z"))]).is_err());
+    }
+
+    #[test]
+    fn reports_the_offending_fee_index() {
+        let fees = vec![fee(None, None), fee(Some("2026-08-01T00:00:00Z"), None)];
+        assert!(
+            validate_service_periods(&fees)
+                .unwrap_err()
+                .contains("index 1")
+        );
     }
 }


### PR DESCRIPTION
Two independent changes, one commit each.

---

## 1. `create_invoice` service period (`c301d17`)

Adds `from_datetime` / `to_datetime` to the fees accepted by `create_invoice`, so a one-off fee can carry the service period it covers.

Depends on [`lago-rust-client#59`](https://github.com/getlago/lago-rust-client/pull/59) — merged and published as `lago-types 0.1.25`. Bumped here from `0.1.24`.

**Why it needed an SDK change:** `POST /invoices` has always accepted these on each entry of `invoice.fees[]`, but `CreateInvoiceFeeInput` didn't model them, so there was nowhere to put the values — the tool could accept the args and they'd be dropped before the HTTP call.

**The pairing constraint.** The API rejects a fee that sets only one boundary. JSON Schema can't express that (Mistral's strict mode validates field types and required fields, not cross-field rules), so it's checked in the handler:

```
Fee at index 0 (add_on_code 'setup_fee') sets only one of from_datetime /
to_datetime. A service period needs both boundaries, or neither.
```

The check runs before the Lago client is constructed, so a malformed call never reaches the API and the model gets something it can act on rather than a 422. The tool description also states the constraint. Three unit tests cover it.

---

## 2. Make the ghcr `latest` tag track `main` (`7912b3f`)

The shared build workflow's metadata-action tag list has no `latest` rule, so `latest` only moves via `latest=auto` on a semver tag push. This repo has cut one git tag ever (`0.1.0`), so `latest` has pointed at that build since 2025-11-17 while every merge updated only `main` and `sha-<commit>`.

Verified against the last build ([run 32121787082](https://github.com/getlago/lago-agent-toolkit/actions/runs/32121787082), commit `9ceb8be`), whose metadata step emitted exactly two tags:

```
ghcr.io/getlago/mcp-server:main
ghcr.io/getlago/mcp-server:sha-9ceb8be
```

Consequence: anyone pulling `latest` gets a nine-month-old server advertising 8 tools, missing every tool added since — and the failure is silent, because absent tools simply never appear in `tools/list`.

Passing a `tags:` input appends to the shared workflow's rule list, so nothing changes in `getlago/lago`. The paths filter already covers this file, so the merge that lands this triggers a build and sets `latest` immediately.

**Decision worth confirming:** this redefines `latest` as tip-of-main rather than last-release. On a future semver tag push both rules write `latest`, landing it on the tagged commit until the next merge moves it back. If `latest` should stay a release pointer, drop this commit and cut tags instead.

---

## Verification

All five CI steps run locally:

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` (15 passed, including 3 new)
- [x] `cargo test --all-features`
- [x] `cargo check --release`

Smoke tested against a locally built server over stdio:

- `tools/list` advertises `from_datetime` / `to_datetime` on `CreateInvoiceFeeArgs` with the updated tool description
- calling `create_invoice` with only `from_datetime` returns the error above

## After merge

The `create_invoice` schema changes, so it needs re-pasting into the **staging and production Mistral agents** — per `docs/adding-new-tool.md` Phase 5/6, the server can advertise the new args but the LLM won't see them until the function schema is updated.